### PR TITLE
Chore: Dependabot now adds skip-release label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,13 @@ updates:
     schedule:
       interval: 'monthly'
     open-pull-requests-limit: 10
+    labels:
+      - 'skip-release'
 
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
+    labels:
+      - 'skip-release'


### PR DESCRIPTION
## Changes

Add labels for dependabot, but appears this repo is missing `skip-release` label

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
