### PR TITLE
Add array and object utils

### DIFF
--- a/docs/ARRAY-UTILS.md
+++ b/docs/ARRAY-UTILS.md
@@ -1,0 +1,6 @@
+# arrayUtils
+
+`chunk<T>(array: T[], chunkSize: number): T[][]`
+
+Splits `array` into an array of arrays, each sub-array being no larger than the provided `chunkSize`,
+preserving original order of the elements.

--- a/docs/OBJECT-UTILS.md
+++ b/docs/OBJECT-UTILS.md
@@ -1,0 +1,29 @@
+# objectUtils
+
+`copyWithoutUndefined<T extends Record<K, V>, K extends string | number | symbol, V>(
+  originalValue: T,
+): T`
+
+Returns an object which contains same field as the `originalValue`, excluding the fields with the value of `undefined`.
+
+`pick<T, K extends string | number | symbol>(
+source: T,
+propNames: readonly K[],
+): Pick<T, Exclude<keyof T, Exclude<keyof T, K>>>`
+
+Returns an object which contains fields specified in `propNames` with the same values as fields in `originalValue`.
+
+`pickWithoutUndefined<T, K extends string | number | symbol>(
+source: T,
+propNames: readonly K[],
+): Pick<T, Exclude<keyof T, Exclude<keyof T, K>>>`
+
+Returns an object which contains fields specified in `propNames` with the same values as fields in `originalValue`, excluding the fields with the value of `undefined`.
+
+`isEmptyObject(params: Record<string, any>): boolean`
+
+Returns true if `params` has no own properties or only own properties with value `undefined`, false otherwise.
+
+`groupBy<T>(inputArray: T[], propName: string): Record<string, T[]>`
+
+Returns an object composed of keys generated from the values of `propName` field for the `inputArray` elements. The order of grouped values is determined by the order they occur in collection.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,0 @@
-# docs
-
-Information of how to use `node-core` package.

--- a/index.ts
+++ b/index.ts
@@ -32,3 +32,12 @@ export type {
 } from './src/config/configTypes'
 
 export type { Either } from './src/errors/either'
+
+export { chunk } from './src/utils/arrayUtils'
+export {
+  groupBy,
+  pick,
+  pickWithoutUndefined,
+  copyWithoutUndefined,
+  isEmptyObject,
+} from './src/utils/objectUtils'

--- a/package.json
+++ b/package.json
@@ -34,22 +34,22 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "undici": "^5.14.0"
+    "undici": "^5.16.0"
   },
   "devDependencies": {
-    "@types/jest": "^29.2.5",
+    "@types/jest": "^29.2.6",
     "@types/node": "^18.11.18",
-    "@typescript-eslint/eslint-plugin": "^5.48.0",
-    "@typescript-eslint/parser": "^5.48.0",
+    "@typescript-eslint/eslint-plugin": "^5.49.0",
+    "@typescript-eslint/parser": "^5.49.0",
     "auto-changelog": "^2.4.0",
-    "eslint": "^8.31.0",
+    "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jest": "^27.2.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.3.1",
-    "prettier": "^2.8.1",
-    "ts-jest": "^29.0.3",
+    "prettier": "^2.8.3",
+    "ts-jest": "^29.0.5",
     "typescript": "4.9.4"
   }
 }

--- a/src/utils/__snapshots__/objectUtils.spec.ts.snap
+++ b/src/utils/__snapshots__/objectUtils.spec.ts.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`groupBy Correctly groups by number values 1`] = `
+{
+  "10": [
+    {
+      "count": 10,
+      "id": 1,
+    },
+    {
+      "count": 10,
+      "id": 2,
+    },
+  ],
+  "20": [
+    {
+      "count": 20,
+      "id": 3,
+    },
+  ],
+  "30": [
+    {
+      "count": 30,
+      "id": 4,
+    },
+  ],
+}
+`;
+
+exports[`groupBy Correctly groups by string values 1`] = `
+{
+  "a": [
+    {
+      "id": 1,
+      "name": "a",
+    },
+    {
+      "id": 4,
+      "name": "a",
+    },
+  ],
+  "b": [
+    {
+      "id": 3,
+      "name": "b",
+    },
+  ],
+  "c": [
+    {
+      "id": 2,
+      "name": "c",
+    },
+  ],
+}
+`;
+
+exports[`groupBy Correctly handles undefined 1`] = `
+{
+  "45": [
+    {
+      "id": 1,
+      "name": "45",
+    },
+    {
+      "id": 4,
+      "name": "45",
+    },
+  ],
+  "undefined": [
+    {
+      "id": 2,
+    },
+    {
+      "id": 3,
+    },
+  ],
+}
+`;
+
+exports[`objectUtils copyWithoutUndefined Does nothing when there are no undefined fields 1`] = `
+{
+  "a": "a",
+  "b": "",
+  "c": " ",
+  "d": null,
+  "e": {},
+}
+`;
+
+exports[`objectUtils copyWithoutUndefined Removes undefined fields 1`] = `
+{
+  "b": "a",
+  "c": "",
+  "e": " ",
+  "f": null,
+  "g": {},
+}
+`;
+
+exports[`pick Ignores missing fields 1`] = `
+{
+  "a": "a",
+}
+`;
+
+exports[`pick Includes undefined fields 1`] = `
+{
+  "a": "a",
+  "b": undefined,
+}
+`;
+
+exports[`pick Picks specified fields 1`] = `
+{
+  "a": "a",
+  "c": " ",
+  "e": {},
+}
+`;
+
+exports[`pickWithoutUndefined Ignores missing fields 1`] = `
+{
+  "a": "a",
+}
+`;
+
+exports[`pickWithoutUndefined Picks specified fields 1`] = `
+{
+  "a": "a",
+  "c": " ",
+  "e": {},
+}
+`;
+
+exports[`pickWithoutUndefined Skips undefined fields 1`] = `
+{
+  "a": "a",
+}
+`;

--- a/src/utils/arrayUtils.spec.ts
+++ b/src/utils/arrayUtils.spec.ts
@@ -1,0 +1,36 @@
+import { chunk } from './arrayUtils'
+
+describe('chunk', () => {
+  it('empty array returns empty array', () => {
+    const result = chunk([], 5)
+    expect(result).toEqual([])
+  })
+
+  it('0 size returns empty array', () => {
+    const result = chunk([1, 2, 3], 0)
+    expect(result).toEqual([])
+  })
+
+  it('returns entire array if chunk size equal to length', () => {
+    const result = chunk([1, 2, 3], 3)
+    expect(result).toEqual([[1, 2, 3]])
+  })
+
+  it('returns entire array if chunk size larger than length', () => {
+    const result = chunk([1, 2, 3], 5)
+    expect(result).toEqual([[1, 2, 3]])
+  })
+
+  it('returns empty array if negative length', () => {
+    const result = chunk([1, 2, 3, 4, 5, 6, 7, 8, 9], -1)
+    expect(result).toEqual([])
+  })
+
+  it('returns chunked array', () => {
+    const result = chunk([1, 2, 3, 4, 5, 6, 7], 5)
+    expect(result).toEqual([
+      [1, 2, 3, 4, 5],
+      [6, 7],
+    ])
+  })
+})

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,20 +1,3 @@
-function slice<T>(array: T[], start: number, end: number): T[] {
-  let length = array.length
-
-  end = end > length ? length : end
-  length = (end - start) >>> 0
-  start >>>= 0
-
-  let index = -1
-  const result = new Array(length)
-  while (++index < length) {
-    result[index] = array[index + start]
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return result
-}
-
 export function chunk<T>(array: T[], chunkSize: number): T[][] {
   const length = array.length
   if (!length || chunkSize < 1) {
@@ -25,7 +8,7 @@ export function chunk<T>(array: T[], chunkSize: number): T[][] {
   const result = new Array(Math.ceil(length / chunkSize))
 
   while (index < length) {
-    result[resIndex++] = slice(array, index, (index += chunkSize))
+    result[resIndex++] = array.slice(index, (index += chunkSize))
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,0 +1,33 @@
+function slice<T>(array: T[], start: number, end: number): T[] {
+  let length = array.length
+
+  end = end > length ? length : end
+  length = (end - start) >>> 0
+  start >>>= 0
+
+  let index = -1
+  const result = new Array(length)
+  while (++index < length) {
+    result[index] = array[index + start]
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return result
+}
+
+export function chunk<T>(array: T[], chunkSize: number): T[][] {
+  const length = array.length
+  if (!length || chunkSize < 1) {
+    return []
+  }
+  let index = 0
+  let resIndex = 0
+  const result = new Array(Math.ceil(length / chunkSize))
+
+  while (index < length) {
+    result[resIndex++] = slice(array, index, (index += chunkSize))
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return result
+}

--- a/src/utils/objectUtils.spec.ts
+++ b/src/utils/objectUtils.spec.ts
@@ -1,0 +1,229 @@
+import {
+  copyWithoutUndefined,
+  groupBy,
+  isEmptyObject,
+  pick,
+  pickWithoutUndefined,
+} from './objectUtils'
+
+describe('objectUtils', () => {
+  describe('copyWithoutUndefined', () => {
+    it('Does nothing when there are no undefined fields', () => {
+      const result = copyWithoutUndefined({
+        a: 'a',
+        b: '',
+        c: ' ',
+        d: null,
+        e: {},
+      })
+
+      expect(result).toMatchSnapshot()
+    })
+
+    it('Removes undefined fields', () => {
+      const result = copyWithoutUndefined({
+        a: undefined,
+        b: 'a',
+        c: '',
+        d: undefined,
+        e: ' ',
+        f: null,
+        g: {},
+        h: undefined,
+      })
+
+      expect(result).toMatchSnapshot()
+    })
+  })
+})
+
+describe('pick', () => {
+  it('Picks specified fields', () => {
+    const result = pick(
+      {
+        a: 'a',
+        b: '',
+        c: ' ',
+        d: null,
+        e: {},
+      },
+      ['a', 'c', 'e'],
+    )
+
+    expect(result).toMatchSnapshot()
+  })
+
+  it('Ignores missing fields', () => {
+    const result = pick(
+      {
+        a: 'a',
+        b: '',
+        c: ' ',
+        d: null,
+        e: {},
+      },
+      ['a', 'f', 'g'],
+    )
+
+    expect(result).toMatchSnapshot()
+  })
+
+  it('Includes undefined fields', () => {
+    const result = pick(
+      {
+        a: 'a',
+        b: undefined,
+        c: {},
+      },
+      ['a', 'b'],
+    )
+
+    expect(result).toMatchSnapshot()
+  })
+})
+
+describe('pickWithoutUndefined', () => {
+  it('Picks specified fields', () => {
+    const result = pickWithoutUndefined(
+      {
+        a: 'a',
+        b: '',
+        c: ' ',
+        d: null,
+        e: {},
+      },
+      ['a', 'c', 'e'],
+    )
+
+    expect(result).toMatchSnapshot()
+  })
+
+  it('Ignores missing fields', () => {
+    const result = pickWithoutUndefined(
+      {
+        a: 'a',
+        b: '',
+        c: ' ',
+        d: null,
+        e: {},
+      },
+      ['a', 'f', 'g'],
+    )
+
+    expect(result).toMatchSnapshot()
+  })
+
+  it('Skips undefined fields', () => {
+    const result = pickWithoutUndefined(
+      {
+        a: 'a',
+        b: undefined,
+        c: {},
+      },
+      ['a', 'b'],
+    )
+
+    expect(result).toMatchSnapshot()
+  })
+})
+
+describe('isEmptyObject', () => {
+  it('Returns true for completely empty object', () => {
+    const params = {}
+    const result = isEmptyObject(params)
+    expect(result).toBe(true)
+  })
+
+  it('Returns true for object with only undefined fields', () => {
+    const params = { a: undefined }
+    const result = isEmptyObject(params)
+    expect(result).toBe(true)
+  })
+
+  it('Returns false for object with null', () => {
+    const params = { a: null }
+    const result = isEmptyObject(params)
+    expect(result).toBe(false)
+  })
+
+  it('Returns false for non-empty object', () => {
+    const params = { a: '' }
+    const result = isEmptyObject(params)
+    expect(result).toBe(false)
+  })
+})
+
+describe('groupBy', () => {
+  it('Correctly groups by string values', () => {
+    const input = [
+      {
+        id: 1,
+        name: 'a',
+      },
+      {
+        id: 2,
+        name: 'c',
+      },
+      {
+        id: 3,
+        name: 'b',
+      },
+      {
+        id: 4,
+        name: 'a',
+      },
+    ]
+
+    const result = groupBy(input, 'name')
+
+    expect(result).toMatchSnapshot()
+  })
+
+  it('Correctly groups by number values', () => {
+    const input = [
+      {
+        id: 1,
+        count: 10,
+      },
+      {
+        id: 2,
+        count: 10,
+      },
+      {
+        id: 3,
+        count: 20,
+      },
+      {
+        id: 4,
+        count: 30,
+      },
+    ]
+
+    const result = groupBy(input, 'count')
+
+    expect(result).toMatchSnapshot()
+  })
+
+  it('Correctly handles undefined', () => {
+    const input = [
+      {
+        id: 1,
+        name: '45',
+      },
+      {
+        id: 2,
+      },
+      {
+        id: 3,
+      },
+      {
+        id: 4,
+        name: '45',
+      },
+    ]
+
+    const result = groupBy(input, 'name')
+
+    expect(result).toMatchSnapshot()
+  })
+})

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -1,0 +1,78 @@
+export function copyWithoutUndefined<T extends Record<K, V>, K extends string | number | symbol, V>(
+  originalValue: T,
+): T {
+  return Object.keys(originalValue).reduce((acc, key) => {
+    // @ts-ignore
+    if (originalValue[key] !== undefined) {
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      acc[key] = originalValue[key]
+    }
+    return acc
+  }, {} as Record<string, unknown>) as T
+}
+
+export function pick<T, K extends string | number | symbol>(
+  source: T,
+  propNames: readonly K[],
+): Pick<T, Exclude<keyof T, Exclude<keyof T, K>>> {
+  const result = {} as T
+  let idx = 0
+  while (idx < propNames.length) {
+    // @ts-ignore
+    if (propNames[idx] in source) {
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      result[propNames[idx]] = source[propNames[idx]]
+    }
+    idx += 1
+  }
+  return result
+}
+
+export function pickWithoutUndefined<T, K extends string | number | symbol>(
+  source: T,
+  propNames: readonly K[],
+): Pick<T, Exclude<keyof T, Exclude<keyof T, K>>> {
+  const result = {} as T
+  let idx = 0
+  while (idx < propNames.length) {
+    // @ts-ignore
+    if (propNames[idx] in source && source[propNames[idx]] !== undefined) {
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      result[propNames[idx]] = source[propNames[idx]]
+    }
+    idx += 1
+  }
+  return result
+}
+
+export function isEmptyObject(params: Record<string, unknown>): boolean {
+  for (const key in params) {
+    if (Object.prototype.hasOwnProperty.call(params, key) && params[key] !== undefined) {
+      return false
+    }
+  }
+  return true
+}
+
+export function groupBy<T>(inputArray: T[], propName: string): Record<string, T[]> {
+  return inputArray.reduce((result, entry) => {
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
+    const key = entry[propName]
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    if (Object.hasOwnProperty.call(result, key)) {
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
+      result[key].push(entry)
+    } else {
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      result[key] = [entry]
+    }
+    return result
+  }, {})
+}


### PR DESCRIPTION
## Changes

Utils for working with arrays (chunking) and objects (copy, pick, groupBy, isEmptyObject).
Adopted wholesale from https://github.com/knex/knex-utils

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
