### PR TITLE
Fix TS compilation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "undici": "^5.16.0"
+    "undici": "^5.17.1"
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",
     "@types/node": "^18.11.18",
-    "@typescript-eslint/eslint-plugin": "^5.49.0",
-    "@typescript-eslint/parser": "^5.49.0",
+    "@typescript-eslint/eslint-plugin": "^5.50.0",
+    "@typescript-eslint/parser": "^5.50.0",
     "auto-changelog": "^2.4.0",
-    "eslint": "^8.32.0",
+    "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
@@ -50,6 +50,6 @@
     "jest": "^29.4.1",
     "prettier": "^2.8.3",
     "ts-jest": "^29.0.5",
-    "typescript": "4.9.4"
+    "typescript": "4.9.5"
   }
 }

--- a/src/http/httpClient.ts
+++ b/src/http/httpClient.ts
@@ -4,6 +4,7 @@ import { request } from 'undici'
 import type { Dispatcher, FormData } from 'undici'
 
 import { InternalError } from '../errors/InternalError'
+import { copyWithoutUndefined } from '../utils/objectUtils'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RecordObject = Record<string, any>
@@ -52,10 +53,10 @@ export async function sendGet<T>(
   const response = await request(url, {
     method: 'GET',
     query: options.query,
-    headers: {
+    headers: copyWithoutUndefined({
       'x-request-id': options.reqContext?.reqId,
       ...options.headers,
-    },
+    }),
     bodyTimeout: options.timeout,
     throwOnError: options.throwOnError,
   })
@@ -80,10 +81,10 @@ export async function sendDelete<T>(
   const response = await request(url, {
     method: 'DELETE',
     query: options.query,
-    headers: {
+    headers: copyWithoutUndefined({
       'x-request-id': options.reqContext?.reqId,
       ...options.headers,
-    },
+    }),
     bodyTimeout: options.timeout,
     throwOnError: options.throwOnError,
   })
@@ -110,10 +111,10 @@ export async function sendPost<T>(
     method: 'POST',
     body: body ? JSON.stringify(body) : undefined,
     query: options.query,
-    headers: {
+    headers: copyWithoutUndefined({
       'x-request-id': options.reqContext?.reqId,
       ...options.headers,
-    },
+    }),
     bodyTimeout: options.timeout,
     throwOnError: options.throwOnError,
   })
@@ -140,10 +141,10 @@ export async function sendPut<T>(
     method: 'PUT',
     body: body ? JSON.stringify(body) : undefined,
     query: options.query,
-    headers: {
+    headers: copyWithoutUndefined({
       'x-request-id': options.reqContext?.reqId,
       ...options.headers,
-    },
+    }),
     bodyTimeout: options.timeout,
     throwOnError: options.throwOnError,
   })
@@ -170,10 +171,10 @@ export async function sendPutBinary<T>(
     method: 'PUT',
     body,
     query: options.query,
-    headers: {
+    headers: copyWithoutUndefined({
       'x-request-id': options.reqContext?.reqId,
       ...options.headers,
-    },
+    }),
     bodyTimeout: options.timeout,
     throwOnError: options.throwOnError,
   })
@@ -200,10 +201,10 @@ export async function sendPatch<T>(
     method: 'PATCH',
     body: body ? JSON.stringify(body) : undefined,
     query: options.query,
-    headers: {
+    headers: copyWithoutUndefined({
       'x-request-id': options.reqContext?.reqId,
       ...options.headers,
-    },
+    }),
     bodyTimeout: options.timeout,
     throwOnError: options.throwOnError,
   })
@@ -220,8 +221,8 @@ export async function sendPatch<T>(
 }
 
 async function resolveBody(response: Dispatcher.ResponseData, safeParseJson = false) {
-  const contentType = response.headers['content-type']
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  // There can never be multiple content-type headers, see https://www.rfc-editor.org/rfc/rfc7230#section-3.2.2
+  const contentType = response.headers['content-type'] as string | undefined
   if (contentType?.startsWith('application/json')) {
     if (!safeParseJson) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/src/http/httpClient.ts
+++ b/src/http/httpClient.ts
@@ -221,6 +221,7 @@ export async function sendPatch<T>(
 
 async function resolveBody(response: Dispatcher.ResponseData, safeParseJson = false) {
   const contentType = response.headers['content-type']
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   if (contentType?.startsWith('application/json')) {
     if (!safeParseJson) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/src/utils/__snapshots__/objectUtils.spec.ts.snap
+++ b/src/utils/__snapshots__/objectUtils.spec.ts.snap
@@ -93,7 +93,9 @@ exports[`objectUtils copyWithoutUndefined Removes undefined fields 1`] = `
   "c": "",
   "e": " ",
   "f": null,
-  "g": {},
+  "g": {
+    "someParam": 12,
+  },
 }
 `;
 

--- a/src/utils/objectUtils.spec.ts
+++ b/src/utils/objectUtils.spec.ts
@@ -28,7 +28,9 @@ describe('objectUtils', () => {
         d: undefined,
         e: ' ',
         f: null,
-        g: {},
+        g: {
+          someParam: 12,
+        },
         h: undefined,
       })
 
@@ -36,7 +38,15 @@ describe('objectUtils', () => {
         string,
         string | Record<string, unknown> | null
       >
-      expect(varWithNarrowedType).toBeTruthy()
+      const bValue: string = varWithNarrowedType.b
+      const gValue: {
+        someParam: number
+      } = varWithNarrowedType.g
+
+      expect(bValue).toBe('a')
+      expect(gValue).toEqual({
+        someParam: 12,
+      })
 
       expect(result).toMatchSnapshot()
     })

--- a/src/utils/objectUtils.spec.ts
+++ b/src/utils/objectUtils.spec.ts
@@ -32,6 +32,12 @@ describe('objectUtils', () => {
         h: undefined,
       })
 
+      const varWithNarrowedType = result satisfies Record<
+        string,
+        string | Record<string, unknown> | null
+      >
+      expect(varWithNarrowedType).toBeTruthy()
+
       expect(result).toMatchSnapshot()
     })
   })

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -1,7 +1,13 @@
-export function copyWithoutUndefined<SourceKeys extends string | number | symbol, SourceValues>(
-  originalValue: Record<SourceKeys, SourceValues>,
-): Record<SourceKeys, Exclude<SourceValues, undefined>> {
-  const result = Object.keys(originalValue).reduce((acc, key) => {
+export function copyWithoutUndefined<
+  T extends Record<string | number | symbol, unknown>,
+  TargetRecordType = Pick<
+    T,
+    {
+      [Prop in keyof T]: T[Prop] extends null | undefined ? never : Prop
+    }[keyof T]
+  >,
+>(originalValue: T): TargetRecordType {
+  return Object.keys(originalValue).reduce((acc, key) => {
     // @ts-ignore
     if (originalValue[key] !== undefined) {
       // @ts-ignore
@@ -9,9 +15,7 @@ export function copyWithoutUndefined<SourceKeys extends string | number | symbol
       acc[key] = originalValue[key]
     }
     return acc
-  }, {} as Record<string, unknown>) as Record<SourceKeys, Exclude<SourceValues, undefined>>
-
-  return result
+  }, {} as Record<string, unknown>) as TargetRecordType
 }
 
 export function pick<T, K extends string | number | symbol>(

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -1,7 +1,7 @@
-export function copyWithoutUndefined<T extends Record<K, V>, K extends string | number | symbol, V>(
-  originalValue: T,
-): T {
-  return Object.keys(originalValue).reduce((acc, key) => {
+export function copyWithoutUndefined<SourceKeys extends string | number | symbol, SourceValues>(
+  originalValue: Record<SourceKeys, SourceValues>,
+): Record<SourceKeys, Exclude<SourceValues, undefined>> {
+  const result = Object.keys(originalValue).reduce((acc, key) => {
     // @ts-ignore
     if (originalValue[key] !== undefined) {
       // @ts-ignore
@@ -9,7 +9,9 @@ export function copyWithoutUndefined<T extends Record<K, V>, K extends string | 
       acc[key] = originalValue[key]
     }
     return acc
-  }, {} as Record<string, unknown>) as T
+  }, {} as Record<string, unknown>) as Record<SourceKeys, Exclude<SourceValues, undefined>>
+
+  return result
 }
 
 export function pick<T, K extends string | number | symbol>(


### PR DESCRIPTION
## Changes

Improved TS types for copyWithUndefined to properly return result without possible undefined values.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
