### PR TITLE
Support configuring or disabling keep-alive

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     "@typescript-eslint/no-non-null-assertion": "warn",
     "@typescript-eslint/no-var-requires": "off",
     "@typescript-eslint/indent": "off",
+    "@typescript-eslint/no-unsafe-assignment": "off",
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/consistent-type-imports": "warn",

--- a/index.ts
+++ b/index.ts
@@ -6,14 +6,9 @@ export {
   sendGet,
   sendPost,
   httpClient,
+  buildClient,
 } from './src/http/httpClient'
-export type {
-  GetRequestOptions,
-  DeleteRequestOptions,
-  RequestOptions,
-  Response,
-  HttpRequestContext,
-} from './src/http/httpClient'
+export type { RequestOptions, Response, HttpRequestContext } from './src/http/httpClient'
 
 export { PublicNonRecoverableError } from './src/errors/PublicNonRecoverableError'
 export type { PublicNonRecoverableErrorParams } from './src/errors/PublicNonRecoverableError'

--- a/package.json
+++ b/package.json
@@ -34,21 +34,21 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "undici": "^5.17.1"
+    "undici": "^5.18.0"
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",
-    "@types/node": "^18.11.18",
-    "@typescript-eslint/eslint-plugin": "^5.50.0",
-    "@typescript-eslint/parser": "^5.50.0",
+    "@types/node": "^18.13.0",
+    "@typescript-eslint/eslint-plugin": "^5.51.0",
+    "@typescript-eslint/parser": "^5.51.0",
     "auto-changelog": "^2.4.0",
     "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-prettier": "^4.2.1",
-    "jest": "^29.4.1",
-    "prettier": "^2.8.3",
+    "jest": "^29.4.2",
+    "prettier": "^2.8.4",
     "ts-jest": "^29.0.5",
     "typescript": "4.9.5"
   }

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -11,7 +11,6 @@ export function copyWithoutUndefined<
     // @ts-ignore
     if (originalValue[key] !== undefined) {
       // @ts-ignore
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       acc[key] = originalValue[key]
     }
     return acc
@@ -28,7 +27,6 @@ export function pick<T, K extends string | number | symbol>(
     // @ts-ignore
     if (propNames[idx] in source) {
       // @ts-ignore
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       result[propNames[idx]] = source[propNames[idx]]
     }
     idx += 1
@@ -46,7 +44,6 @@ export function pickWithoutUndefined<T, K extends string | number | symbol>(
     // @ts-ignore
     if (propNames[idx] in source && source[propNames[idx]] !== undefined) {
       // @ts-ignore
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       result[propNames[idx]] = source[propNames[idx]]
     }
     idx += 1
@@ -66,7 +63,7 @@ export function isEmptyObject(params: Record<string, unknown>): boolean {
 export function groupBy<T>(inputArray: T[], propName: string): Record<string, T[]> {
   return inputArray.reduce((result, entry) => {
     // @ts-ignore
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-assignment
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const key = entry[propName]
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument


### PR DESCRIPTION
## Changes

Keep-Alive header behaviour can be configured now.
Use smaller defaults to ensure we are below automatic AWS load balancer disconnects

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the tests, or no changes were necessary
