### PR TITLE
Support retry logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "undici": "^5.19.0",
+    "undici": "^5.19.1",
     "undici-retry": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "undici": "^5.18.0"
+    "undici": "^5.19.0",
+    "undici-retry": "^1.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",

--- a/src/errors/either.ts
+++ b/src/errors/either.ts
@@ -16,3 +16,11 @@ type Right<U> = {
  * @see {@link https://antman-does-software.com/stop-catching-errors-in-typescript-use-the-either-type-to-make-your-code-predictable Further reading on motivation for Either type}
  */
 export type Either<T, U> = NonNullable<Left<T> | Right<U>>
+
+/***
+ * Variation of Either, which may or may not have Error set, but always has Result
+ */
+export type DefiniteEither<T, U> = {
+  error?: T
+  result: U
+}

--- a/src/http/httpClient.spec.ts
+++ b/src/http/httpClient.spec.ts
@@ -177,6 +177,40 @@ describe('httpClient', () => {
         },
       })
     })
+
+    it('Works with retry', async () => {
+      expect.assertions(1)
+      const query = {
+        limit: 3,
+      }
+
+      client
+        .intercept({
+          path: '/products',
+          method: 'GET',
+          query,
+        })
+        .reply(500, 'Invalid request')
+      client
+        .intercept({
+          path: '/products',
+          method: 'GET',
+          query,
+        })
+        .reply(200, 'OK')
+
+      const response = await sendGet(client, '/products', {
+        query,
+        retryConfig: {
+          statusCodesToRetry: [500],
+          retryOnTimeout: false,
+          delayBetweenAttemptsInMsecs: 0,
+          maxAttempts: 2,
+        },
+      })
+
+      expect(response.result.body).toBe('OK')
+    })
   })
 
   describe('DELETE', () => {

--- a/src/http/httpClient.spec.ts
+++ b/src/http/httpClient.spec.ts
@@ -75,7 +75,7 @@ describe('httpClient', () => {
 
       const result = await sendGet(client, '/products/1')
 
-      expect(result.body).toEqual(mockProduct1)
+      expect(result.result.body).toEqual(mockProduct1)
     })
 
     it('GET returning text', async () => {
@@ -90,7 +90,7 @@ describe('httpClient', () => {
 
       const result = await sendGet(client, '/products/1')
 
-      expect(result.body).toBe('just text')
+      expect(result.result.body).toBe('just text')
     })
 
     it('GET returning text without content type', async () => {
@@ -101,9 +101,9 @@ describe('httpClient', () => {
         })
         .reply(200, 'just text', {})
 
-      const result = await sendGet(client, '/products/1')
+      const result = await sendGet<string>(client, '/products/1')
 
-      expect(result.body).toBe('just text')
+      expect(result.result.body).toBe('just text')
     })
 
     it('GET with queryParams', async () => {
@@ -123,7 +123,7 @@ describe('httpClient', () => {
         query,
       })
 
-      expect(result.body).toEqual(mockProductsLimit3)
+      expect(result.result.body).toEqual(mockProductsLimit3)
     })
 
     it('Throws an error on internal error', async () => {
@@ -168,7 +168,13 @@ describe('httpClient', () => {
           query,
         }),
       ).rejects.toMatchObject({
-        message: 'connection error',
+        message: 'Response status code 400',
+        details: {
+          response: {
+            body: 'Invalid request',
+            statusCode: 400,
+          },
+        },
       })
     })
   })
@@ -184,8 +190,8 @@ describe('httpClient', () => {
 
       const result = await sendDelete(client, '/products/1')
 
-      expect(result.statusCode).toBe(204)
-      expect(result.body).toBe('')
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
     })
 
     it('DELETE with queryParams', async () => {
@@ -205,8 +211,8 @@ describe('httpClient', () => {
         query,
       })
 
-      expect(result.statusCode).toBe(204)
-      expect(result.body).toBe('')
+      expect(result.result.statusCode).toBe(204)
+      expect(result.result.body).toBe('')
     })
 
     it('Throws an error on internal error', async () => {
@@ -244,7 +250,7 @@ describe('httpClient', () => {
 
       const result = await sendPost(client, '/products', mockProduct1)
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('POST without body', async () => {
@@ -257,7 +263,7 @@ describe('httpClient', () => {
 
       const result = await sendPost(client, '/products', undefined)
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('POST with queryParams', async () => {
@@ -277,7 +283,7 @@ describe('httpClient', () => {
         query,
       })
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('POST that returns 400 throws an error', async () => {
@@ -289,7 +295,7 @@ describe('httpClient', () => {
         .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(sendPost(client, '/products', mockProduct1)).rejects.toThrow(
-        'Response status code 400: Bad Request',
+        'Response status code 400',
       )
     })
 
@@ -328,7 +334,7 @@ describe('httpClient', () => {
 
       const result = await sendPut(client, '/products/1', mockProduct1)
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('PUT without body', async () => {
@@ -341,7 +347,7 @@ describe('httpClient', () => {
 
       const result = await sendPut(client, '/products/1', undefined)
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('PUT with queryParams', async () => {
@@ -361,7 +367,7 @@ describe('httpClient', () => {
         query,
       })
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('PUT that returns 400 throws an error', async () => {
@@ -373,7 +379,7 @@ describe('httpClient', () => {
         .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(sendPut(client, '/products/1', mockProduct1)).rejects.toThrow(
-        'Response status code 400: Bad Request',
+        'Response status code 400',
       )
     })
 
@@ -412,7 +418,7 @@ describe('httpClient', () => {
 
       const result = await sendPutBinary(client, '/products/1', Buffer.from('text'))
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('PUT with queryParams', async () => {
@@ -432,7 +438,7 @@ describe('httpClient', () => {
         query,
       })
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('PUT that returns 400 throws an error', async () => {
@@ -444,7 +450,7 @@ describe('httpClient', () => {
         .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(sendPutBinary(client, '/products/1', Buffer.from('text'))).rejects.toThrow(
-        'Response status code 400: Bad Request',
+        'Response status code 400',
       )
     })
 
@@ -483,7 +489,7 @@ describe('httpClient', () => {
 
       const result = await sendPatch(client, '/products/1', mockProduct1)
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('PATCH without body', async () => {
@@ -496,7 +502,7 @@ describe('httpClient', () => {
 
       const result = await sendPatch(client, '/products/1', undefined)
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('PATCH with queryParams', async () => {
@@ -516,7 +522,7 @@ describe('httpClient', () => {
         query,
       })
 
-      expect(result.body).toEqual({ id: 21 })
+      expect(result.result.body).toEqual({ id: 21 })
     })
 
     it('PATCH that returns 400 throws an error', async () => {
@@ -528,7 +534,7 @@ describe('httpClient', () => {
         .reply(400, { errorCode: 'err' }, { headers: JSON_HEADERS })
 
       await expect(sendPatch(client, '/products/1', mockProduct1)).rejects.toThrow(
-        'Response status code 400: Bad Request',
+        'Response status code 400',
       )
     })
 

--- a/src/http/httpClient.spec.ts
+++ b/src/http/httpClient.spec.ts
@@ -125,6 +125,52 @@ describe('httpClient', () => {
 
       expect(result.body).toEqual(mockProductsLimit3)
     })
+
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
+      const query = {
+        limit: 3,
+      }
+
+      client
+        .intercept({
+          path: '/products',
+          method: 'GET',
+          query,
+        })
+        .replyWithError(new Error('connection error'))
+
+      await expect(
+        sendGet(client, '/products', {
+          query,
+        }),
+      ).rejects.toMatchObject({
+        message: 'connection error',
+      })
+    })
+
+    it('Returns error response', async () => {
+      expect.assertions(1)
+      const query = {
+        limit: 3,
+      }
+
+      client
+        .intercept({
+          path: '/products',
+          method: 'GET',
+          query,
+        })
+        .reply(400, 'Invalid request')
+
+      await expect(
+        sendGet(client, '/products', {
+          query,
+        }),
+      ).rejects.toMatchObject({
+        message: 'connection error',
+      })
+    })
   })
 
   describe('DELETE', () => {
@@ -161,6 +207,29 @@ describe('httpClient', () => {
 
       expect(result.statusCode).toBe(204)
       expect(result.body).toBe('')
+    })
+
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
+      const query = {
+        limit: 3,
+      }
+
+      client
+        .intercept({
+          path: '/products',
+          method: 'DELETE',
+          query,
+        })
+        .replyWithError(new Error('connection error'))
+
+      await expect(
+        sendDelete(client, '/products', {
+          query,
+        }),
+      ).rejects.toMatchObject({
+        message: 'connection error',
+      })
     })
   })
 
@@ -223,6 +292,29 @@ describe('httpClient', () => {
         'Response status code 400: Bad Request',
       )
     })
+
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
+      const query = {
+        limit: 3,
+      }
+
+      client
+        .intercept({
+          path: '/products',
+          method: 'POST',
+          query,
+        })
+        .replyWithError(new Error('connection error'))
+
+      await expect(
+        sendPost(client, '/products', undefined, {
+          query,
+        }),
+      ).rejects.toMatchObject({
+        message: 'connection error',
+      })
+    })
   })
 
   describe('PUT', () => {
@@ -284,6 +376,29 @@ describe('httpClient', () => {
         'Response status code 400: Bad Request',
       )
     })
+
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
+      const query = {
+        limit: 3,
+      }
+
+      client
+        .intercept({
+          path: '/products',
+          method: 'PUT',
+          query,
+        })
+        .replyWithError(new Error('connection error'))
+
+      await expect(
+        sendPut(client, '/products', undefined, {
+          query,
+        }),
+      ).rejects.toMatchObject({
+        message: 'connection error',
+      })
+    })
   })
 
   describe('PUT binary', () => {
@@ -331,6 +446,29 @@ describe('httpClient', () => {
       await expect(sendPutBinary(client, '/products/1', Buffer.from('text'))).rejects.toThrow(
         'Response status code 400: Bad Request',
       )
+    })
+
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
+      const query = {
+        limit: 3,
+      }
+
+      client
+        .intercept({
+          path: '/products',
+          method: 'PUT',
+          query,
+        })
+        .replyWithError(new Error('connection error'))
+
+      await expect(
+        sendPutBinary(client, '/products', null, {
+          query,
+        }),
+      ).rejects.toMatchObject({
+        message: 'connection error',
+      })
     })
   })
 
@@ -392,6 +530,29 @@ describe('httpClient', () => {
       await expect(sendPatch(client, '/products/1', mockProduct1)).rejects.toThrow(
         'Response status code 400: Bad Request',
       )
+    })
+
+    it('Throws an error on internal error', async () => {
+      expect.assertions(1)
+      const query = {
+        limit: 3,
+      }
+
+      client
+        .intercept({
+          path: '/products',
+          method: 'PATCH',
+          query,
+        })
+        .replyWithError(new Error('connection error'))
+
+      await expect(
+        sendPatch(client, '/products', undefined, {
+          query,
+        }),
+      ).rejects.toMatchObject({
+        message: 'connection error',
+      })
     })
   })
 })

--- a/src/http/httpClient.ts
+++ b/src/http/httpClient.ts
@@ -5,9 +5,9 @@ import type { FormData } from 'undici'
 import type { RequestResult, RetryConfig } from 'undici-retry'
 import { DEFAULT_RETRY_CONFIG, sendWithRetry } from 'undici-retry'
 
-import { copyWithoutUndefined } from '../utils/objectUtils'
-import { Either } from '../errors/either'
 import { InternalError } from '../errors/InternalError'
+import type { DefiniteEither, Either } from '../errors/either'
+import { copyWithoutUndefined } from '../utils/objectUtils'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RecordObject = Record<string, any>
@@ -19,7 +19,7 @@ export type HttpRequestContext = {
 export type RequestOptions = {
   headers?: RecordObject
   query?: RecordObject
-  timeout?: number
+  timeout: number | undefined
   throwOnError?: boolean
   reqContext?: HttpRequestContext
   safeParseJson?: boolean
@@ -28,10 +28,10 @@ export type RequestOptions = {
   clientOptions?: Client.Options
 }
 
-const defaultOptions: RequestOptions = {
+const DEFAULT_OPTIONS = {
   throwOnError: true,
   timeout: 30000,
-}
+} satisfies RequestOptions
 
 const defaultClientOptions: Partial<Client.Options> = {
   keepAliveMaxTimeout: 300_000,
@@ -47,11 +47,12 @@ export type Response<T> = {
 export async function sendGet<T>(
   client: Client,
   path: string,
-  options: RequestOptions = defaultOptions,
-): Promise<Either<RequestResult<unknown>, RequestResult<T>>> {
+  options: Partial<RequestOptions> = {},
+): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
   const result = await sendWithRetry<T>(
     client,
     {
+      ...DEFAULT_OPTIONS,
       path: path,
       method: 'GET',
       query: options.query,
@@ -61,22 +62,23 @@ export async function sendGet<T>(
       }),
       reset: options.disableKeepAlive ?? false,
       bodyTimeout: options.timeout,
-      throwOnError: options.throwOnError,
+      throwOnError: false,
     },
     resolveRetryConfig(options),
   )
 
-  return resolveResult(result, options)
+  return resolveResult(result, options.throwOnError ?? DEFAULT_OPTIONS.throwOnError)
 }
 
 export async function sendDelete<T>(
   client: Client,
   path: string,
-  options: RequestOptions = defaultOptions,
-): Promise<Either<RequestResult<unknown>, RequestResult<T>>> {
+  options: Partial<RequestOptions> = {},
+): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
   const result = await sendWithRetry<T>(
     client,
     {
+      ...DEFAULT_OPTIONS,
       path,
       method: 'DELETE',
       query: options.query,
@@ -86,23 +88,24 @@ export async function sendDelete<T>(
       }),
       reset: options.disableKeepAlive ?? false,
       bodyTimeout: options.timeout,
-      throwOnError: options.throwOnError,
+      throwOnError: false,
     },
     resolveRetryConfig(options),
   )
 
-  return resolveResult(result, options)
+  return resolveResult(result, options.throwOnError ?? DEFAULT_OPTIONS.throwOnError)
 }
 
 export async function sendPost<T>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
-  options: RequestOptions = defaultOptions,
-): Promise<Either<RequestResult<unknown>, RequestResult<T>>> {
+  options: Partial<RequestOptions> = {},
+): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
   const result = await sendWithRetry<T>(
     client,
     {
+      ...DEFAULT_OPTIONS,
       path: path,
       method: 'POST',
       body: body ? JSON.stringify(body) : undefined,
@@ -113,22 +116,24 @@ export async function sendPost<T>(
       }),
       reset: options.disableKeepAlive ?? false,
       bodyTimeout: options.timeout,
-      throwOnError: options.throwOnError,
+      throwOnError: false,
     },
     resolveRetryConfig(options),
   )
-  return resolveResult(result, options)
+
+  return resolveResult(result, options.throwOnError ?? DEFAULT_OPTIONS.throwOnError)
 }
 
 export async function sendPut<T>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
-  options: RequestOptions = defaultOptions,
-): Promise<Either<RequestResult<unknown>, RequestResult<T>>> {
+  options: Partial<RequestOptions> = {},
+): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
   const result = await sendWithRetry<T>(
     client,
     {
+      ...DEFAULT_OPTIONS,
       path: path,
       method: 'PUT',
       body: body ? JSON.stringify(body) : undefined,
@@ -139,22 +144,24 @@ export async function sendPut<T>(
       }),
       reset: options.disableKeepAlive ?? false,
       bodyTimeout: options.timeout,
-      throwOnError: options.throwOnError,
+      throwOnError: false,
     },
     resolveRetryConfig(options),
   )
-  return resolveResult(result, options)
+
+  return resolveResult(result, options.throwOnError ?? DEFAULT_OPTIONS.throwOnError)
 }
 
 export async function sendPutBinary<T>(
   client: Client,
   path: string,
   body: Buffer | Uint8Array | Readable | null | FormData,
-  options: RequestOptions = defaultOptions,
-): Promise<Either<RequestResult<unknown>, RequestResult<T>>> {
+  options: Partial<RequestOptions> = {},
+): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
   const result = await sendWithRetry<T>(
     client,
     {
+      ...DEFAULT_OPTIONS,
       path: path,
       method: 'PUT',
       body,
@@ -165,22 +172,24 @@ export async function sendPutBinary<T>(
       }),
       reset: options.disableKeepAlive ?? false,
       bodyTimeout: options.timeout,
-      throwOnError: options.throwOnError,
+      throwOnError: false,
     },
     resolveRetryConfig(options),
   )
-  return resolveResult(result, options)
+
+  return resolveResult(result, options.throwOnError ?? DEFAULT_OPTIONS.throwOnError)
 }
 
 export async function sendPatch<T>(
   client: Client,
   path: string,
   body: RecordObject | undefined,
-  options: RequestOptions = defaultOptions,
-): Promise<Either<RequestResult<unknown>, RequestResult<T>>> {
+  options: Partial<RequestOptions> = {},
+): Promise<DefiniteEither<RequestResult<unknown>, RequestResult<T>>> {
   const result = await sendWithRetry<T>(
     client,
     {
+      ...DEFAULT_OPTIONS,
       path: path,
       method: 'PATCH',
       body: body ? JSON.stringify(body) : undefined,
@@ -191,14 +200,15 @@ export async function sendPatch<T>(
       }),
       reset: options.disableKeepAlive ?? false,
       bodyTimeout: options.timeout,
-      throwOnError: options.throwOnError,
+      throwOnError: false,
     },
     resolveRetryConfig(options),
   )
-  return resolveResult(result, options)
+
+  return resolveResult(result, options.throwOnError ?? DEFAULT_OPTIONS.throwOnError)
 }
 
-function resolveRetryConfig(options: RequestOptions): RetryConfig {
+function resolveRetryConfig(options: Partial<RequestOptions>): RetryConfig {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return options.retryConfig
     ? {
@@ -221,18 +231,18 @@ export function buildClient(baseUrl: string, clientOptions?: Client.Options) {
 
 function resolveResult<T>(
   requestResult: Either<RequestResult<unknown>, RequestResult<T>>,
-  options: RequestOptions,
-) {
-  if (requestResult.error && options.throwOnError) {
+  throwOnError: boolean,
+): DefiniteEither<RequestResult<unknown>, RequestResult<T>> {
+  if (requestResult.error && throwOnError) {
     throw new InternalError({
-      message: `Request error ${requestResult.error.statusCode}`,
+      message: `Response status code ${requestResult.error.statusCode}`,
       details: {
         response: requestResult.error,
       },
       errorCode: 'REQUEST_ERROR',
     })
   }
-  return requestResult
+  return requestResult as DefiniteEither<RequestResult<unknown>, RequestResult<T>>
 }
 
 export const httpClient = {


### PR DESCRIPTION
## Changes

This exposes HTTP client retry logic in an easy to consume format.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the tests, or no changes were necessary
