### PR TITLE
Inconsistent behavior in `ConfigScope` when environment variable is empty (`''`).

### DIFF
--- a/src/config/ConfigScope.spec.ts
+++ b/src/config/ConfigScope.spec.ts
@@ -168,6 +168,15 @@ describe('ConfigScope', () => {
 
       expect(resolvedValue).toBe('def')
     })
+
+    it('uses default value if empty', () => {
+      process.env.value = ''
+      const configScope = new ConfigScope()
+
+      const resolvedValue = configScope.getOptional('value', 'def')
+
+      expect(resolvedValue).toBe('def')
+    })
   })
 
   describe('getOptionalInteger', () => {
@@ -182,6 +191,15 @@ describe('ConfigScope', () => {
 
     it('uses default value if not set', () => {
       delete process.env.value
+      const configScope = new ConfigScope()
+
+      const resolvedValue = configScope.getOptionalInteger('value', 1)
+
+      expect(resolvedValue).toBe(1)
+    })
+
+    it('uses default value if empty', () => {
+      process.env.value = ''
       const configScope = new ConfigScope()
 
       const resolvedValue = configScope.getOptionalInteger('value', 1)


### PR DESCRIPTION
Originally reported [here](https://github.com/lokalise/node-service-template/issues/79). 

**Problem statement**

Given
```env
VAR1=
VAR2=
```
and performing
```ts
var1: configScope.getOptionalInteger('VAR1', 42),
var2: configScope.getOptional('VAR2', 'foo'),
```
the produced configuration has inconsistent fallback behavior
```js
{
    var1: 42,
    var2: '',
}
```


I've added tests in this PR that support this behavior.


**Proposed solution**
Use the same approach that `getOptionalBoolean` has (validate the raw value).
```ts
getOptionalBoolean(param: string, defaultValue: boolean): boolean {
  const rawValue = this.env[param]?.toLowerCase()
  if (rawValue === undefined || rawValue === '') {
    return defaultValue
  }

  validateOneOf(rawValue, ['true', 'false'])

  return rawValue === 'true'
}
```