### PR TITLE
Breaking change: Updated ConfigScope.getOptional to fallback to default value when environment variable is an empty string ('')

### DIFF
--- a/src/config/ConfigScope.spec.ts
+++ b/src/config/ConfigScope.spec.ts
@@ -169,6 +169,9 @@ describe('ConfigScope', () => {
       expect(resolvedValue).toBe('def')
     })
 
+    // This case can happen when variable is in .env file, but is left empty.
+    // Just like this:
+    // VAR1=
     it('uses default value if set to empty string', () => {
       process.env.value = ''
       const configScope = new ConfigScope()
@@ -205,8 +208,8 @@ describe('ConfigScope', () => {
       expect(resolvedValue).toBe('undefined')
     })
 
-    // Side effect of the current implementation that maybe should be fixated
-    it('returns undefined (string) if set to undefined (object)', () => {
+    // Side effect of how node.js handles assigning undefined to process.env
+    it('returns undefined (string) if set to undefined (undefined)', () => {
       process.env.value = undefined
       const configScope = new ConfigScope()
 

--- a/src/config/ConfigScope.spec.ts
+++ b/src/config/ConfigScope.spec.ts
@@ -168,6 +168,61 @@ describe('ConfigScope', () => {
 
       expect(resolvedValue).toBe('def')
     })
+
+    it('uses default value if set to empty string', () => {
+      process.env.value = ''
+      const configScope = new ConfigScope()
+
+      const resolvedValue = configScope.getOptional('value', 'def')
+
+      expect(resolvedValue).toBe('def')
+    })
+
+    it('returns false if set to false', () => {
+      process.env.value = 'false'
+      const configScope = new ConfigScope()
+
+      const resolvedValue = configScope.getOptional('value', 'def')
+
+      expect(resolvedValue).toBe('false')
+    })
+
+    it('returns 0 if set to 0', () => {
+      process.env.value = '0'
+      const configScope = new ConfigScope()
+
+      const resolvedValue = configScope.getOptional('value', 'def')
+
+      expect(resolvedValue).toBe('0')
+    })
+
+    it('returns undefined if set to undefined', () => {
+      process.env.value = 'undefined'
+      const configScope = new ConfigScope()
+
+      const resolvedValue = configScope.getOptional('value', 'def')
+
+      expect(resolvedValue).toBe('undefined')
+    })
+
+    // Side effect of the current implementation that maybe should be fixated
+    it('returns undefined (string) if set to undefined (object)', () => {
+      process.env.value = undefined
+      const configScope = new ConfigScope()
+
+      const resolvedValue = configScope.getOptional('value', 'def')
+
+      expect(resolvedValue).toBe('undefined')
+    })
+
+    it('returns null if set to null', () => {
+      process.env.value = 'null'
+      const configScope = new ConfigScope()
+
+      const resolvedValue = configScope.getOptional('value', 'def')
+
+      expect(resolvedValue).toBe('null')
+    })
   })
 
   describe('getOptionalInteger', () => {

--- a/src/config/ConfigScope.ts
+++ b/src/config/ConfigScope.ts
@@ -71,7 +71,8 @@ export class ConfigScope {
   }
 
   getOptional(param: string, defaultValue: string): string {
-    return this.env[param] ?? defaultValue
+    // Using the `||` operator instead of `??`, since '' is not a valid value, and 0 (number) is not expected here
+    return this.env[param] || defaultValue
   }
 
   getOptionalInteger(param: string, defaultValue: number): number {


### PR DESCRIPTION
## Changes

### Problem statement

Given
```
VAR1=
VAR2=
```
and performing
```
var1: configScope.getOptionalInteger('VAR1', 42),
var2: configScope.getOptional('VAR2', 'foo'),
```
the produced configuration has inconsistent fallback behavior
```
{
    var1: 42,
    var2: '',
}
```


### Proposed solution

Use logical OR operator `||` instead of `??` in `ConfigScope.getOptional`.

### Notes

Taking into account that `configScope.getOptional('VAR2', 'foo') currently returns an empty string, this change has the ability to break an application. 
Both for applications that rely on this behaviour and the ones that were not aware of this fallback behaviour.


## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
