### PR TITLE
Add generic to ResponseStatusError

### DIFF
--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -1,16 +1,16 @@
 export type ErrorDetails = Record<string, unknown>
 
-export type InternalErrorParams = {
+export type InternalErrorParams<T = ErrorDetails> = {
   message: string
   errorCode: string
-  details?: ErrorDetails
+  details?: T
 }
 
-export class InternalError extends Error {
-  public readonly details?: ErrorDetails
+export class InternalError<T = ErrorDetails> extends Error {
+  public readonly details?: T
   public readonly errorCode: string
 
-  constructor(params: InternalErrorParams) {
+  constructor(params: InternalErrorParams<T>) {
     super(params.message)
     this.name = 'InternalError'
     this.details = params.details

--- a/src/errors/ResponseStatusError.ts
+++ b/src/errors/ResponseStatusError.ts
@@ -2,7 +2,11 @@ import type { RequestResult } from 'undici-retry'
 
 import { InternalError } from './InternalError'
 
-export class ResponseStatusError extends InternalError {
+export type ResponseStatusErrorDetails = {
+  response: RequestResult<unknown>
+}
+
+export class ResponseStatusError extends InternalError<ResponseStatusErrorDetails> {
   constructor(requestResult: RequestResult<unknown>) {
     super({
       message: `Response status code ${requestResult.statusCode}`,


### PR DESCRIPTION
## Changes

Make ResponseStatusError type more convenient to use via generic

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
