### PR TITLE
Add type-safe access to response

### DIFF
--- a/src/errors/ResponseStatusError.ts
+++ b/src/errors/ResponseStatusError.ts
@@ -13,8 +13,10 @@ export class ResponseStatusError extends InternalError {
     super({
       message: `Response status code ${requestResult.statusCode}`,
       details: {
-        statusCode: requestResult.statusCode,
-        body: requestResult.body,
+        response: {
+          statusCode: requestResult.statusCode,
+          body: requestResult.body,
+        },
       },
       errorCode: 'REQUEST_ERROR',
     })

--- a/src/errors/ResponseStatusError.ts
+++ b/src/errors/ResponseStatusError.ts
@@ -6,14 +6,18 @@ export type ResponseStatusErrorDetails = {
   response: RequestResult<unknown>
 }
 
-export class ResponseStatusError extends InternalError<ResponseStatusErrorDetails> {
+export class ResponseStatusError extends InternalError {
+  public readonly response: RequestResult<unknown>
+
   constructor(requestResult: RequestResult<unknown>) {
     super({
       message: `Response status code ${requestResult.statusCode}`,
       details: {
-        response: requestResult,
+        statusCode: requestResult.statusCode,
+        body: requestResult.body,
       },
       errorCode: 'REQUEST_ERROR',
     })
+    this.response = requestResult
   }
 }

--- a/src/http/httpClient.spec.ts
+++ b/src/http/httpClient.spec.ts
@@ -254,6 +254,10 @@ describe('httpClient', () => {
         }),
       ).rejects.toMatchObject({
         message: 'Response status code 400',
+        response: {
+          body: 'Invalid request',
+          statusCode: 400,
+        },
         details: {
           response: {
             body: 'Invalid request',


### PR DESCRIPTION
## Changes

Response is always available, so we can expose it more explicitly

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
