### PR TITLE
Better narrowing down of types for getMandatoryOneOf

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,19 +40,19 @@
     "undici-retry": "^1.1.1"
   },
   "devDependencies": {
-    "@types/node": "^20.2.5",
-    "@typescript-eslint/eslint-plugin": "^5.59.9",
-    "@typescript-eslint/parser": "^5.59.9",
-    "@vitest/coverage-v8": "^0.32.0",
+    "@types/node": "^20.3.2",
+    "@typescript-eslint/eslint-plugin": "^5.60.1",
+    "@typescript-eslint/parser": "^5.60.1",
+    "@vitest/coverage-v8": "^0.32.2",
     "auto-changelog": "^2.4.0",
-    "eslint": "^8.42.0",
+    "eslint": "^8.43.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-vitest": "^0.2.5",
+    "eslint-plugin-vitest": "^0.2.6",
     "prettier": "^2.8.8",
-    "typescript": "^5.1.3",
-    "vitest": "^0.32.0",
+    "typescript": "^5.1.6",
+    "vitest": "^0.32.2",
     "zod": "^3.21.4"
   }
 }

--- a/src/config/ConfigScope.ts
+++ b/src/config/ConfigScope.ts
@@ -43,7 +43,7 @@ export class ConfigScope {
     return result
   }
 
-  getMandatoryOneOf<T>(param: string, supportedValues: T[]): T {
+  getMandatoryOneOf<const T>(param: string, supportedValues: T[]): T {
     const result = this.getMandatory(param)
     return validateOneOf(
       result,
@@ -154,7 +154,7 @@ export class ConfigScope {
   }
 }
 
-export function validateOneOf<T>(
+export function validateOneOf<const T>(
   validatedEntity: unknown,
   expectedOneOfEntities: T[],
   errorText?: string,


### PR DESCRIPTION
## Changes

This change improves the Type Guard quality of this function, typing end result as one of the passed values, and not just a generic "string" or "number"

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
