### PR TITLE
Bumping undici-retry to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "pino": "^8.14.1",
     "undici": "^5.22.1",
-    "undici-retry": "^1.1.1"
+    "undici-retry": "^2.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.3.2",


### PR DESCRIPTION
## Changes

Bumping undici-retry to 2.0.1

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
