### PR TITLE
Use newer undici-retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,16 +36,16 @@
   },
   "dependencies": {
     "pino": "^8.16.1",
-    "undici": "^5.27.0",
-    "undici-retry": "^3.1.2"
+    "undici": "^5.27.2",
+    "undici-retry": "^3.2.0"
   },
   "devDependencies": {
-    "@types/node": "^20.8.9",
+    "@types/node": "^20.8.10",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
     "@vitest/coverage-v8": "^0.34.6",
     "auto-changelog": "^2.4.0",
-    "eslint": "^8.52.0",
+    "eslint": "^8.53.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.29.0",
     "eslint-plugin-prettier": "^5.0.1",


### PR DESCRIPTION
## Changes

New undici-retry supports automatic handling of Retry-After

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
