### PR TITLE
Convert date to string

### DIFF
--- a/docs/object-utils.md
+++ b/docs/object-utils.md
@@ -24,10 +24,14 @@ Returns an object which contains fields specified in `propNames` with the same v
 
 Returns true if `params` has no own properties or only own properties with value `undefined`, false otherwise.
 
-`export function groupBy<T extends { [K in keyof T]: string | number | symbol | null | undefined }, K extends keyof T>(array: T[], selector: K): Record<string | number | symbol, T[]>`
+`groupBy<T extends { [K in keyof T]: string | number | symbol | null | undefined }, K extends keyof T>(array: T[], selector: K): Record<string | number | symbol, T[]>`
 
 The `groupBy` function takes an array of objects and a `selector`, groups the objects based on selected key and returns an object with unique keys from the selector and corresponding groups as arrays.
 
-`export function groupByUnique<T extends { [K in keyof T]: string | number | symbol | null | undefined }, K extends keyof T>(array: T[], selector: K): Record<string | number | symbol, T>`
+`groupByUnique<T extends { [K in keyof T]: string | number | symbol | null | undefined }, K extends keyof T>(array: T[], selector: K): Record<string | number | symbol, T>`
 
 Similar to `groupBy`, but the value is a single element, in case of duplicated values for the same selector the method will throw a `InternalError`
+
+`convertDateFieldsToIsoString<Input extends object>(object: Input | Input[],): ExactlyLikeWithDateAsString<Input> | ExactlyLikeWithDateAsString<Input>[]`
+
+Transform an input object with `Date` members into an object with the corresponding `Date` members replaced by their ISO string representation. This transformation is done recursively, covering nested objects as well.

--- a/index.ts
+++ b/index.ts
@@ -43,7 +43,7 @@ export {
   pickWithoutUndefined,
   copyWithoutUndefined,
   isEmptyObject,
-  convertDatesToIsoString,
+  convertDateFieldsToIsoString,
 } from './src/utils/objectUtils'
 
 export {

--- a/index.ts
+++ b/index.ts
@@ -43,6 +43,7 @@ export {
   pickWithoutUndefined,
   copyWithoutUndefined,
   isEmptyObject,
+  convertDatesToIsoString,
 } from './src/utils/objectUtils'
 
 export {

--- a/src/utils/objectUtils.spec.ts
+++ b/src/utils/objectUtils.spec.ts
@@ -385,6 +385,10 @@ describe('objectUtils', () => {
       code: number
       reason?: string | null
       other?: TestInputType
+      array?: {
+        id: number
+        createdAt: Date
+      }[]
     }
 
     type TestExpectedType = {
@@ -393,9 +397,13 @@ describe('objectUtils', () => {
       date: string
       code: number
       other?: TestExpectedType
+      array?: {
+        id: number
+        createdAt: string
+      }[]
     }
 
-    it('simple objects', () => {
+    it('simple object', () => {
       const date = new Date()
       const input: TestInputType = {
         id: 1,
@@ -414,6 +422,46 @@ describe('objectUtils', () => {
         code: 100,
         reason: 'reason',
       })
+    })
+
+    it('simple array', () => {
+      const date1 = new Date()
+      const date2 = new Date()
+      const input: TestInputType[] = [
+        {
+          id: 1,
+          date: date1,
+          value: 'test',
+          reason: 'reason',
+          code: 100,
+        },
+        {
+          id: 2,
+          date: date2,
+          value: 'test 2',
+          reason: 'reason 2',
+          code: 200,
+        },
+      ]
+
+      const output: TestExpectedType[] = convertDatesToIsoString(input)
+
+      expect(output).toStrictEqual([
+        {
+          id: 1,
+          date: date1.toISOString(),
+          value: 'test',
+          code: 100,
+          reason: 'reason',
+        },
+        {
+          id: 2,
+          date: date2.toISOString(),
+          value: 'test 2',
+          code: 200,
+          reason: 'reason 2',
+        },
+      ])
     })
 
     it('handles undefined and null', () => {
@@ -439,7 +487,7 @@ describe('objectUtils', () => {
       })
     })
 
-    it('nested objects', () => {
+    it('nested objects and array', () => {
       const date1 = new Date()
       const date2 = new Date()
       date2.setFullYear(1990)
@@ -457,6 +505,16 @@ describe('objectUtils', () => {
           reason: null,
           other: undefined,
         },
+        array: [
+          {
+            id: 1,
+            createdAt: date1,
+          },
+          {
+            id: 2,
+            createdAt: date2,
+          },
+        ],
       }
 
       const output: TestExpectedType = convertDatesToIsoString(input)
@@ -475,6 +533,16 @@ describe('objectUtils', () => {
           reason: null,
           other: undefined,
         },
+        array: [
+          {
+            id: 1,
+            createdAt: date1.toISOString(),
+          },
+          {
+            id: 2,
+            createdAt: date2.toISOString(),
+          },
+        ],
       })
     })
   })

--- a/src/utils/objectUtils.spec.ts
+++ b/src/utils/objectUtils.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'vitest'
 
 import {
+  convertDatesToIsoString,
   copyWithoutUndefined,
   groupBy,
   groupByUnique,
@@ -369,6 +370,112 @@ describe('objectUtils', () => {
       expect(() => groupByUnique(input, 'name')).toThrowError(
         'Duplicated item for selector name with value test',
       )
+    })
+  })
+
+  describe('convertDatesToIsoString', () => {
+    it('Empty object', () => {
+      expect(convertDatesToIsoString({})).toStrictEqual({})
+    })
+
+    type TestInputType = {
+      id: number
+      value: string
+      date: Date
+      code: number
+      reason?: string | null
+      other?: TestInputType
+    }
+
+    type TestExpectedType = {
+      id: number
+      value: string
+      date: string
+      code: number
+      other?: TestExpectedType
+    }
+
+    it('simple objects', () => {
+      const date = new Date()
+      const input: TestInputType = {
+        id: 1,
+        date,
+        value: 'test',
+        reason: 'reason',
+        code: 100,
+      }
+
+      const output: TestExpectedType = convertDatesToIsoString(input)
+
+      expect(output).toStrictEqual({
+        id: 1,
+        date: date.toISOString(),
+        value: 'test',
+        code: 100,
+        reason: 'reason',
+      })
+    })
+
+    it('handles undefined and null', () => {
+      const date = new Date()
+      const input: TestInputType = {
+        id: 1,
+        date,
+        value: 'test',
+        code: 100,
+        reason: null,
+        other: undefined,
+      }
+
+      const output: TestExpectedType = convertDatesToIsoString(input)
+
+      expect(output).toStrictEqual({
+        id: 1,
+        date: date.toISOString(),
+        value: 'test',
+        code: 100,
+        reason: null,
+        other: undefined,
+      })
+    })
+
+    it('nested objects', () => {
+      const date1 = new Date()
+      const date2 = new Date()
+      date2.setFullYear(1990)
+      const input: TestInputType = {
+        id: 1,
+        date: date1,
+        value: 'test',
+        code: 100,
+        reason: 'reason',
+        other: {
+          id: 2,
+          value: 'test 2',
+          date: date2,
+          code: 200,
+          reason: null,
+          other: undefined,
+        },
+      }
+
+      const output: TestExpectedType = convertDatesToIsoString(input)
+
+      expect(output).toMatchObject({
+        id: 1,
+        date: date1.toISOString(),
+        value: 'test',
+        code: 100,
+        reason: 'reason',
+        other: {
+          id: 2,
+          value: 'test 2',
+          date: date2.toISOString(),
+          code: 200,
+          reason: null,
+          other: undefined,
+        },
+      })
     })
   })
 })

--- a/src/utils/objectUtils.spec.ts
+++ b/src/utils/objectUtils.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'vitest'
 
 import {
-  convertDatesToIsoString,
+  convertDateFieldsToIsoString,
   copyWithoutUndefined,
   groupBy,
   groupByUnique,
@@ -373,9 +373,9 @@ describe('objectUtils', () => {
     })
   })
 
-  describe('convertDatesToIsoString', () => {
+  describe('convertDateFieldsToIsoString', () => {
     it('Empty object', () => {
-      expect(convertDatesToIsoString({})).toStrictEqual({})
+      expect(convertDateFieldsToIsoString({})).toStrictEqual({})
     })
 
     type TestInputType = {
@@ -413,7 +413,7 @@ describe('objectUtils', () => {
         code: 100,
       }
 
-      const output: TestExpectedType = convertDatesToIsoString(input)
+      const output: TestExpectedType = convertDateFieldsToIsoString(input)
 
       expect(output).toStrictEqual({
         id: 1,
@@ -444,7 +444,7 @@ describe('objectUtils', () => {
         },
       ]
 
-      const output: TestExpectedType[] = convertDatesToIsoString(input)
+      const output: TestExpectedType[] = convertDateFieldsToIsoString(input)
 
       expect(output).toStrictEqual([
         {
@@ -475,7 +475,7 @@ describe('objectUtils', () => {
         other: undefined,
       }
 
-      const output: TestExpectedType = convertDatesToIsoString(input)
+      const output: TestExpectedType = convertDateFieldsToIsoString(input)
 
       expect(output).toStrictEqual({
         id: 1,
@@ -517,7 +517,7 @@ describe('objectUtils', () => {
         ],
       }
 
-      const output: TestExpectedType = convertDatesToIsoString(input)
+      const output: TestExpectedType = convertDateFieldsToIsoString(input)
 
       expect(output).toMatchObject({
         id: 1,

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -129,7 +129,7 @@ type DatesAsString<T> = T extends Date
   : T extends object
   ? ExactlyLikeWithDateAsString<T>
   : T
-export type ExactlyLikeWithDateAsString<T> = {
+type ExactlyLikeWithDateAsString<T> = {
   [K in keyof T]: DatesAsString<T[K]>
 }
 export function convertDatesToIsoString<Input extends object>(

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -140,7 +140,7 @@ export function convertDatesToIsoString<Input extends object>(
       result[key] = convertDatesToIsoString(value)
     } else {
       // @ts-ignore
-      result[key] = value instanceof Date ? value.toISOString() : value
+      result[key] = value
     }
     return result
   }, {} as ExactlyLikeWithDateAsString<Input>)

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -123,3 +123,29 @@ export function groupByUnique<
     {} as Record<RecordKeyType, T>,
   )
 }
+
+type DatesAsString<T> = T extends Date
+  ? string
+  : T extends object
+  ? ExactlyLikeWithDateAsString<T>
+  : T
+export type ExactlyLikeWithDateAsString<T> = {
+  [K in keyof T]: DatesAsString<T[K]>
+}
+export function convertDatesToIsoString<Input extends object>(
+  object: Input,
+): ExactlyLikeWithDateAsString<Input> {
+  return Object.entries(object).reduce((result, [key, value]) => {
+    if (value instanceof Date) {
+      // @ts-ignore
+      result[key] = value.toISOString()
+    } else if (value && typeof value === 'object') {
+      // @ts-ignore
+      result[key] = convertDatesToIsoString(value)
+    } else {
+      // @ts-ignore
+      result[key] = value instanceof Date ? value.toISOString() : value
+    }
+    return result
+  }, {} as ExactlyLikeWithDateAsString<Input>)
+}

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -128,17 +128,17 @@ type DatesAsString<T> = T extends Date ? string : ExactlyLikeWithDateAsString<T>
 
 type ExactlyLikeWithDateAsString<T> = T extends object ? { [K in keyof T]: DatesAsString<T[K]> } : T
 
-export function convertDatesToIsoString<Input extends object>(
+export function convertDateFieldsToIsoString<Input extends object>(
   object: Input,
 ): ExactlyLikeWithDateAsString<Input>
-export function convertDatesToIsoString<Input extends object>(
+export function convertDateFieldsToIsoString<Input extends object>(
   object: Input[],
 ): ExactlyLikeWithDateAsString<Input>[]
-export function convertDatesToIsoString<Input extends object>(
+export function convertDateFieldsToIsoString<Input extends object>(
   object: Input | Input[],
 ): ExactlyLikeWithDateAsString<Input> | ExactlyLikeWithDateAsString<Input>[] {
   if (Array.isArray(object)) {
-    return object.map((item) => convertDatesToIsoString(item))
+    return object.map((item) => convertDateFieldsToIsoString(item))
   }
 
   return Object.entries(object).reduce((result, [key, value]) => {
@@ -147,7 +147,7 @@ export function convertDatesToIsoString<Input extends object>(
       result[key] = value.toISOString()
     } else if (value && typeof value === 'object') {
       // @ts-ignore
-      result[key] = convertDatesToIsoString(value)
+      result[key] = convertDateFieldsToIsoString(value)
     } else {
       // @ts-ignore
       result[key] = value

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -124,15 +124,10 @@ export function groupByUnique<
   )
 }
 
-type DatesAsString<T> = T extends Date
-  ? string
-  : T extends object
-  ? ExactlyLikeWithDateAsString<T>
-  : T
+type DatesAsString<T> = T extends Date ? string : ExactlyLikeWithDateAsString<T>
 
-type ExactlyLikeWithDateAsString<T> = {
-  [K in keyof T]: DatesAsString<T[K]>
-}
+type ExactlyLikeWithDateAsString<T> = T extends object ? { [K in keyof T]: DatesAsString<T[K]> } : T
+
 export function convertDatesToIsoString<Input extends object>(
   object: Input,
 ): ExactlyLikeWithDateAsString<Input> {

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -129,6 +129,7 @@ type DatesAsString<T> = T extends Date
   : T extends object
   ? ExactlyLikeWithDateAsString<T>
   : T
+
 type ExactlyLikeWithDateAsString<T> = {
   [K in keyof T]: DatesAsString<T[K]>
 }

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -130,7 +130,17 @@ type ExactlyLikeWithDateAsString<T> = T extends object ? { [K in keyof T]: Dates
 
 export function convertDatesToIsoString<Input extends object>(
   object: Input,
-): ExactlyLikeWithDateAsString<Input> {
+): ExactlyLikeWithDateAsString<Input>
+export function convertDatesToIsoString<Input extends object>(
+  object: Input[],
+): ExactlyLikeWithDateAsString<Input>[]
+export function convertDatesToIsoString<Input extends object>(
+  object: Input | Input[],
+): ExactlyLikeWithDateAsString<Input> | ExactlyLikeWithDateAsString<Input>[] {
+  if (Array.isArray(object)) {
+    return object.map((item) => convertDatesToIsoString(item))
+  }
+
   return Object.entries(object).reduce((result, [key, value]) => {
     if (value instanceof Date) {
       // @ts-ignore


### PR DESCRIPTION
## Changes

Adding `convertDatesToIsoString` to transform an input object with `Date` members into an object with the corresponding `Date` members replaced by their ISO string representation. This transformation is done recursively, covering nested objects as well.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
