### PR TITLE
Group by bug fix

### DIFF
--- a/docs/object-utils.md
+++ b/docs/object-utils.md
@@ -24,11 +24,11 @@ Returns an object which contains fields specified in `propNames` with the same v
 
 Returns true if `params` has no own properties or only own properties with value `undefined`, false otherwise.
 
-`groupBy<T extends { [K in keyof T]: string | number | symbol | null | undefined }, K extends keyof T>(array: T[], selector: K): Record<string | number | symbol, T[]>`
+`export function groupBy<T extends object, K extends KeysMatching<T, RecordKeyType | null | undefined>>(array: T[], selector: K): Record<RecordKeyType, T[]> {`
 
 The `groupBy` function takes an array of objects and a `selector`, groups the objects based on selected key and returns an object with unique keys from the selector and corresponding groups as arrays.
 
-`groupByUnique<T extends { [K in keyof T]: string | number | symbol | null | undefined }, K extends keyof T>(array: T[], selector: K): Record<string | number | symbol, T>`
+`export function groupByUnique<T extends object, K extends KeysMatching<T, RecordKeyType | null | undefined>>(array: T[], selector: K): Record<RecordKeyType, T>`
 
 Similar to `groupBy`, but the value is a single element, in case of duplicated values for the same selector the method will throw a `InternalError`
 

--- a/src/utils/objectUtils.spec.ts
+++ b/src/utils/objectUtils.spec.ts
@@ -212,7 +212,6 @@ describe('objectUtils', () => {
           name: 'a',
           bool: true,
           nested: { code: 400 },
-          bug,
         },
       ]
 

--- a/src/utils/objectUtils.spec.ts
+++ b/src/utils/objectUtils.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest'
+import { expect, expectTypeOf } from 'vitest'
 
 import {
   convertDateFieldsToIsoString,
@@ -178,94 +178,172 @@ describe('objectUtils', () => {
       expect(Object.keys(result)).length(0)
     })
 
+    type TestType = {
+      id?: number | null
+      name: string
+      bool: boolean
+      nested?: {
+        code: number
+      }
+    }
+
     it('Correctly groups by string values', () => {
-      const input: { name: string }[] = [
+      const input: TestType[] = [
         {
           id: 1,
           name: 'a',
+          bool: true,
+          nested: { code: 100 },
         },
         {
           id: 2,
           name: 'c',
+          bool: true,
+          nested: { code: 200 },
         },
         {
           id: 3,
           name: 'b',
+          bool: true,
+          nested: { code: 300 },
         },
         {
           id: 4,
           name: 'a',
+          bool: true,
+          nested: { code: 400 },
+          bug,
         },
-      ] as never[]
+      ]
 
-      const result: Record<string, { name: string }[]> = groupBy(input, 'name')
-
+      const result: Record<string, TestType[]> = groupBy(input, 'name')
       expect(result).toStrictEqual({
         a: [
-          { id: 1, name: 'a' },
-          { id: 4, name: 'a' },
+          {
+            id: 1,
+            name: 'a',
+            bool: true,
+            nested: { code: 100 },
+          },
+          {
+            id: 4,
+            name: 'a',
+            bool: true,
+            nested: { code: 400 },
+          },
         ],
-        b: [{ id: 3, name: 'b' }],
-        c: [{ id: 2, name: 'c' }],
+        b: [
+          {
+            id: 3,
+            name: 'b',
+            bool: true,
+            nested: { code: 300 },
+          },
+        ],
+        c: [
+          {
+            id: 2,
+            name: 'c',
+            bool: true,
+            nested: { code: 200 },
+          },
+        ],
       })
     })
 
     it('Correctly groups by number values', () => {
-      const input: { count: number }[] = [
+      const input: TestType[] = [
         {
           id: 1,
-          count: 10,
+          name: 'a',
+          bool: true,
+        },
+        {
+          id: 1,
+          name: 'b',
+          bool: false,
         },
         {
           id: 2,
-          count: 20,
+          name: 'c',
+          bool: false,
         },
         {
           id: 3,
-          count: 30,
+          name: 'd',
+          bool: false,
         },
-        {
-          id: 4,
-          count: 10,
-        },
-      ] as never[]
+      ]
 
-      const result: Record<number, { count: number }[]> = groupBy(input, 'count')
+      const result: Record<number, TestType[]> = groupBy(input, 'id')
 
       expect(result).toStrictEqual({
-        10: [
-          { id: 1, count: 10 },
-          { id: 4, count: 10 },
+        1: [
+          {
+            id: 1,
+            name: 'a',
+            bool: true,
+          },
+          {
+            id: 1,
+            name: 'b',
+            bool: false,
+          },
         ],
-        20: [{ id: 2, count: 20 }],
-        30: [{ id: 3, count: 30 }],
+        2: [
+          {
+            id: 2,
+            name: 'c',
+            bool: false,
+          },
+        ],
+        3: [
+          {
+            id: 3,
+            name: 'd',
+            bool: false,
+          },
+        ],
       })
     })
 
-    it('Correctly handles undefined', () => {
-      const input: { name?: string }[] = [
+    it('Correctly handles undefined and null', () => {
+      const input: TestType[] = [
         {
           id: 1,
-          name: 'name',
+          name: 'a',
+          bool: true,
         },
         {
-          id: 2,
+          name: 'c',
+          bool: true,
         },
         {
-          id: 3,
+          id: null,
+          name: 'd',
+          bool: true,
         },
         {
-          id: 4,
-          name: 'name',
+          id: 1,
+          name: 'b',
+          bool: true,
         },
-      ] as never[]
+      ]
 
-      const result = groupBy(input, 'name')
+      const result = groupBy(input, 'id')
 
       expect(result).toStrictEqual({
-        name: [
-          { id: 1, name: 'name' },
-          { id: 4, name: 'name' },
+        1: [
+          {
+            id: 1,
+            name: 'a',
+            bool: true,
+          },
+          {
+            id: 1,
+            name: 'b',
+            bool: true,
+          },
         ],
       })
     })
@@ -278,76 +356,119 @@ describe('objectUtils', () => {
       expect(Object.keys(result)).length(0)
     })
 
+    type TestType = {
+      id?: number | null
+      name: string
+      bool: boolean
+      nested: {
+        code: number
+      }
+    }
+
     it('Correctly groups by string values', () => {
-      const input: { name: string }[] = [
+      const input: TestType[] = [
         {
           id: 1,
           name: 'a',
+          bool: true,
+          nested: { code: 100 },
         },
         {
           id: 2,
           name: 'b',
+          bool: true,
+          nested: { code: 200 },
         },
-        {
-          id: 3,
-          name: 'c',
-        },
-      ] as never[]
+      ]
 
-      const result: Record<string, { name: string }> = groupByUnique(input, 'name')
-
+      const result: Record<string, TestType> = groupByUnique(input, 'name')
       expect(result).toStrictEqual({
-        a: { id: 1, name: 'a' },
-        b: { id: 2, name: 'b' },
-        c: { id: 3, name: 'c' },
+        a: {
+          id: 1,
+          name: 'a',
+          bool: true,
+          nested: { code: 100 },
+        },
+
+        b: {
+          id: 2,
+          name: 'b',
+          bool: true,
+          nested: { code: 200 },
+        },
       })
     })
 
     it('Correctly groups by number values', () => {
-      const input: { count: number }[] = [
+      const input: TestType[] = [
         {
           id: 1,
-          count: 10,
+          name: 'a',
+          bool: true,
+          nested: { code: 100 },
         },
         {
           id: 2,
-          count: 20,
+          name: 'b',
+          bool: true,
+          nested: { code: 200 },
         },
-        {
-          id: 3,
-          count: 30,
-        },
-      ] as never[]
+      ]
 
-      const result: Record<number, { count: number }> = groupByUnique(input, 'count')
+      const result: Record<number, TestType> = groupByUnique(input, 'id')
 
       expect(result).toStrictEqual({
-        10: { id: 1, count: 10 },
-        20: { id: 2, count: 20 },
-        30: { id: 3, count: 30 },
+        1: {
+          id: 1,
+          name: 'a',
+          bool: true,
+          nested: { code: 100 },
+        },
+        2: {
+          id: 2,
+          name: 'b',
+          bool: true,
+          nested: { code: 200 },
+        },
       })
     })
 
     it('Correctly handles undefined', () => {
-      const input: { name?: string }[] = [
+      const input: TestType[] = [
         {
           id: 1,
           name: 'name',
+          bool: true,
+          nested: { code: 100 },
         },
         {
-          id: 2,
+          name: 'invalid',
+          bool: true,
+          nested: { code: 100 },
         },
         {
           id: 3,
           name: 'name 2',
+          bool: true,
+          nested: { code: 100 },
         },
-      ] as never[]
+      ]
 
-      const result = groupByUnique(input, 'name')
+      const result = groupByUnique(input, 'id')
 
       expect(result).toStrictEqual({
-        name: { id: 1, name: 'name' },
-        'name 2': { id: 3, name: 'name 2' },
+        1: {
+          id: 1,
+          name: 'name',
+          bool: true,
+          nested: { code: 100 },
+        },
+        3: {
+          id: 3,
+          name: 'name 2',
+          bool: true,
+          nested: { code: 100 },
+        },
       })
     })
 
@@ -422,6 +543,7 @@ describe('objectUtils', () => {
         code: 100,
         reason: 'reason',
       })
+      expectTypeOf(output).toMatchTypeOf<TestExpectedType>()
     })
 
     it('simple array', () => {

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -67,19 +67,20 @@ export function isEmptyObject(params: Record<string, unknown>): boolean {
   return true
 }
 
+type KeysMatching<T, V> = { [K in keyof T]: T[K] extends V ? K : never }[keyof T]
+
 /**
  * @param array The array of objects to be grouped.
  * @param selector The key used for grouping the objects.
- * @returns An object where the keys are unique values from the given selector and the values are the corresponding
- *  objects from the array.
+ * @returns An object where the keys are unique values from the given selector and the values are the corresponding objects from the array.
  */
 export function groupBy<
-  T extends { [K in keyof T]: RecordKeyType | null | undefined },
-  K extends keyof T,
+  T extends object,
+  K extends KeysMatching<T, RecordKeyType | null | undefined>,
 >(array: T[], selector: K): Record<RecordKeyType, T[]> {
   return array.reduce(
     (acc, item) => {
-      const key = item[selector]
+      const key = item[selector] as RecordKeyType | null | undefined
       if (key === undefined || key === null) {
         return acc
       }
@@ -101,12 +102,12 @@ export function groupBy<
  * @throws InternalError If a duplicated value is found for the given selector.
  */
 export function groupByUnique<
-  T extends { [K in keyof T]: RecordKeyType | null | undefined },
-  K extends keyof T,
+  T extends object,
+  K extends KeysMatching<T, RecordKeyType | null | undefined>,
 >(array: T[], selector: K): Record<RecordKeyType, T> {
   return array.reduce(
     (acc, item) => {
-      const key = item[selector]
+      const key = item[selector] as RecordKeyType | null | undefined
       if (key === undefined || key === null) {
         return acc
       }


### PR DESCRIPTION
## Changes

We were forcing to all props in `T` to be of type `string` `number` or `symbol`, where only `selector` one should have that type, so we allow to use the method with object with nested object, boolean properties or arrays

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
