### PR TITLE
Make error handling more consistent

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "pino": "^8.17.0",
     "undici": "^6.0.1",
-    "undici-retry": "^4.0.0"
+    "undici-retry": "^5.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.10.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "pino": "^8.17.1",
     "undici": "^6.0.1",
-    "undici-retry": "^5.0.1"
+    "undici-retry": "^5.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.10.4",

--- a/src/http/httpClient.ts
+++ b/src/http/httpClient.ts
@@ -3,7 +3,8 @@ import type { Readable } from 'stream'
 import { Client } from 'undici'
 import type { FormData } from 'undici'
 import type { RequestResult, RequestParams, RetryConfig } from 'undici-retry'
-import { NO_RETRY_CONFIG, sendWithRetry } from 'undici-retry'
+import { isRequestResult, NO_RETRY_CONFIG, sendWithRetry } from 'undici-retry'
+import type { InternalRequestError } from 'undici-retry/dist/lib/InternalRequestError'
 
 import { ResponseStatusError } from '../errors/ResponseStatusError'
 import type { DefiniteEither, Either } from '../errors/either'
@@ -295,7 +296,7 @@ function resolveRequestConfig(options: Partial<RequestOptions<unknown>>): Reques
   return {
     safeParseJson: options.safeParseJson ?? false,
     blobBody: options.blobResponseBody ?? false,
-    throwOnInternalError: true,
+    throwOnInternalError: false,
     requestLabel: options.requestLabel,
   }
 }
@@ -313,7 +314,7 @@ export function buildClient(baseUrl: string, clientOptions?: Client.Options) {
 }
 
 function resolveResult<T>(
-  requestResult: Either<RequestResult<unknown>, RequestResult<T>>,
+  requestResult: Either<RequestResult<unknown> | InternalRequestError, RequestResult<T>>,
   throwOnError: boolean,
   validateResponse: boolean,
   validationSchema?: ResponseSchema,
@@ -321,7 +322,10 @@ function resolveResult<T>(
 ): DefiniteEither<RequestResult<unknown>, RequestResult<T>> {
   // Throw response error
   if (requestResult.error && throwOnError) {
-    throw new ResponseStatusError(requestResult.error, requestLabel)
+    if (isRequestResult(requestResult.error)) {
+      throw new ResponseStatusError(requestResult.error, requestLabel)
+    }
+    throw requestResult.error
   }
   if (requestResult.result && validateResponse && validationSchema) {
     requestResult.result.body = validationSchema.parse(requestResult.result.body)

--- a/src/http/httpClient.ts
+++ b/src/http/httpClient.ts
@@ -2,9 +2,8 @@ import type { Readable } from 'stream'
 
 import { Client } from 'undici'
 import type { FormData } from 'undici'
-import type { RequestResult, RequestParams, RetryConfig } from 'undici-retry'
 import { isRequestResult, NO_RETRY_CONFIG, sendWithRetry } from 'undici-retry'
-import type { InternalRequestError } from 'undici-retry/dist/lib/InternalRequestError'
+import type { RequestResult, RequestParams, RetryConfig, InternalRequestError } from 'undici-retry'
 
 import type { MayOmit } from '../common/may-omit'
 import { ResponseStatusError } from '../errors/ResponseStatusError'


### PR DESCRIPTION
## Changes

Now internal error are handled the same way as non-2xx block response errors, and are returned either as Either or thrown depending on the same config parameter.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
