### PR TITLE
Export either helpers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,9 +14,16 @@ export {
   type ResponseSchema,
 } from './src/http/httpClient'
 
-export { PublicNonRecoverableError, type PublicNonRecoverableErrorParams } from './src/errors/PublicNonRecoverableError'
+export {
+  PublicNonRecoverableError,
+  type PublicNonRecoverableErrorParams,
+} from './src/errors/PublicNonRecoverableError'
 
-export { InternalError, type ErrorDetails, type InternalErrorParams } from './src/errors/InternalError'
+export {
+  InternalError,
+  type ErrorDetails,
+  type InternalErrorParams,
+} from './src/errors/InternalError'
 export { ResponseStatusError } from './src/errors/ResponseStatusError'
 
 export { ConfigScope } from './src/config/ConfigScope'
@@ -55,7 +62,11 @@ export { type StandardizedError } from './src/utils/typeUtils'
 export { resolveLoggerConfiguration } from './src/logging/loggerConfigResolver'
 export { type AppLoggerConfig } from './src/logging/loggerConfigResolver'
 
-export { type ErrorReport, type ErrorReporter, type ErrorResolver } from './src/errors/errorReporterTypes'
+export {
+  type ErrorReport,
+  type ErrorReporter,
+  type ErrorResolver,
+} from './src/errors/errorReporterTypes'
 export {
   executeAsyncAndHandleGlobalErrors,
   executeAndHandleGlobalErrors,

--- a/index.ts
+++ b/index.ts
@@ -8,32 +8,28 @@ export {
   sendPostBinary,
   httpClient,
   buildClient,
-} from './src/http/httpClient'
-export type {
-  RequestOptions,
-  Response,
-  HttpRequestContext,
-  ResponseSchema,
+  type RequestOptions,
+  type Response,
+  type HttpRequestContext,
+  type ResponseSchema,
 } from './src/http/httpClient'
 
-export { PublicNonRecoverableError } from './src/errors/PublicNonRecoverableError'
-export type { PublicNonRecoverableErrorParams } from './src/errors/PublicNonRecoverableError'
+export { PublicNonRecoverableError, type PublicNonRecoverableErrorParams } from './src/errors/PublicNonRecoverableError'
 
-export { InternalError } from './src/errors/InternalError'
+export { InternalError, type ErrorDetails, type InternalErrorParams } from './src/errors/InternalError'
 export { ResponseStatusError } from './src/errors/ResponseStatusError'
-export type { ErrorDetails, InternalErrorParams } from './src/errors/InternalError'
 
 export { ConfigScope } from './src/config/ConfigScope'
 export { ensureClosingSlashTransformer } from './src/config/configTransformers'
 export { createRangeValidator } from './src/config/configValidators'
-export type {
-  EnvValueValidator,
-  EnvValueTransformer,
-  AppConfig,
-  RedisConfig,
+export {
+  type EnvValueValidator,
+  type EnvValueTransformer,
+  type AppConfig,
+  type RedisConfig,
 } from './src/config/configTypes'
 
-export type { Either } from './src/errors/either'
+export { type Either, success, failure, isSuccess, isFailure } from './src/errors/either'
 
 export { chunk, callChunked, removeFalsy, removeNullish } from './src/utils/arrayUtils'
 export {
@@ -54,12 +50,12 @@ export {
   isPublicNonRecoverableError,
   hasMessage,
 } from './src/utils/typeUtils'
-export type { StandardizedError } from './src/utils/typeUtils'
+export { type StandardizedError } from './src/utils/typeUtils'
 
 export { resolveLoggerConfiguration } from './src/logging/loggerConfigResolver'
-export type { AppLoggerConfig } from './src/logging/loggerConfigResolver'
+export { type AppLoggerConfig } from './src/logging/loggerConfigResolver'
 
-export type { ErrorReport, ErrorReporter, ErrorResolver } from './src/errors/errorReporterTypes'
+export { type ErrorReport, type ErrorReporter, type ErrorResolver } from './src/errors/errorReporterTypes'
 export {
   executeAsyncAndHandleGlobalErrors,
   executeAndHandleGlobalErrors,
@@ -68,6 +64,6 @@ export {
   resolveGlobalErrorLogObject,
 } from './src/errors/globalErrorHandler'
 
-export type { MayOmit } from './src/common/may-omit'
+export { type MayOmit } from './src/common/may-omit'
 
 export { waitAndRetry } from './src/utils/waitUtils'


### PR DESCRIPTION
## Changes

The new `success`, `failure`, `isSuccess`, `isFailure` helpers for the `Either` type were not being exported from the main index, and as such were inaccessible for consumers. This PR fixes that.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
