### PR TITLE
Add typeguard for ResponseStatusError

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,7 @@ export {
   type InternalErrorParams,
 } from './src/errors/InternalError'
 export { ResponseStatusError } from './src/errors/ResponseStatusError'
+export { isResponseStatusError } from './src/errors/errorTypeGuards'
 
 export { ConfigScope } from './src/config/ConfigScope'
 export { ensureClosingSlashTransformer } from './src/config/configTransformers'

--- a/src/errors/ResponseStatusError.ts
+++ b/src/errors/ResponseStatusError.ts
@@ -5,6 +5,7 @@ import { InternalError } from './InternalError'
 export class ResponseStatusError extends InternalError {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public readonly response: RequestResult<any>
+  public readonly isResponseStatusError = true
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(requestResult: RequestResult<any>, requestLabel = 'N/A') {

--- a/src/errors/errorTypeGuards.spec.ts
+++ b/src/errors/errorTypeGuards.spec.ts
@@ -1,0 +1,25 @@
+import { describe } from 'vitest'
+
+import { InternalError } from './InternalError'
+import { ResponseStatusError } from './ResponseStatusError'
+import { isResponseStatusError } from './errorTypeGuards'
+
+describe('errorTypeGuards', () => {
+  describe('isResponseStatusError', () => {
+    it('Returns true for ResponseStatusError', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-explicit-any
+      const error = new ResponseStatusError({} as any, 'label')
+
+      expect(isResponseStatusError(error)).toBe(true)
+    })
+
+    it('Returns false for not a ResponseStatusError', () => {
+      const error = new InternalError({
+        message: 'message',
+        errorCode: 'CODE',
+      })
+
+      expect(isResponseStatusError(error)).toBe(false)
+    })
+  })
+})

--- a/src/errors/errorTypeGuards.ts
+++ b/src/errors/errorTypeGuards.ts
@@ -1,0 +1,5 @@
+import type { ResponseStatusError } from './ResponseStatusError'
+
+export function isResponseStatusError(entity: unknown): entity is ResponseStatusError {
+  return 'isResponseStatusError' in (entity as ResponseStatusError)
+}


### PR DESCRIPTION
## Changes

More robust way to check if error is an instance of ResponseStatusError

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
