### PR TITLE
Add passthrough of error.cause for PublicNonRecoverableError & InternalError

### DIFF
--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -4,6 +4,7 @@ export type InternalErrorParams<T = ErrorDetails> = {
   message: string
   errorCode: string
   details?: T
+  cause?: Error
 }
 
 export class InternalError<T = ErrorDetails> extends Error {
@@ -11,7 +12,9 @@ export class InternalError<T = ErrorDetails> extends Error {
   public readonly errorCode: string
 
   constructor(params: InternalErrorParams<T>) {
-    super(params.message)
+    super(params.message, {
+      cause: params.cause,
+    })
     this.name = 'InternalError'
     this.details = params.details
     this.errorCode = params.errorCode

--- a/src/errors/PublicNonRecoverableError.ts
+++ b/src/errors/PublicNonRecoverableError.ts
@@ -5,6 +5,7 @@ export type PublicNonRecoverableErrorParams = {
   errorCode: string
   details?: ErrorDetails
   httpStatusCode?: number
+  cause?: Error
 }
 
 /**
@@ -16,7 +17,9 @@ export class PublicNonRecoverableError extends Error {
   public readonly httpStatusCode: number
 
   constructor(params: PublicNonRecoverableErrorParams) {
-    super(params.message)
+    super(params.message, {
+      cause: params.cause,
+    })
     this.name = 'PublicNonRecoverableError'
     this.details = params.details
     this.errorCode = params.errorCode

--- a/src/errors/publicErrors.ts
+++ b/src/errors/publicErrors.ts
@@ -7,12 +7,10 @@ import { PublicNonRecoverableError } from './PublicNonRecoverableError'
 export type CommonErrorParams = {
   message: string
   details?: FreeformRecord
+  cause?: Error
 }
 
-export type OptionalMessageErrorParams = {
-  message?: string
-  details?: FreeformRecord
-}
+export type OptionalMessageErrorParams = Partial<CommonErrorParams>
 
 export type ValidationError = {
   message: string
@@ -39,6 +37,7 @@ export class AccessDeniedError extends PublicNonRecoverableError {
       errorCode: 'ACCESS_DENIED',
       httpStatusCode: httpConstants.HTTP_STATUS_FORBIDDEN,
       details: params.details,
+      cause: params.cause
     })
   }
 }
@@ -50,6 +49,7 @@ export class EntityNotFoundError extends PublicNonRecoverableError {
       errorCode: 'ENTITY_NOT_FOUND',
       httpStatusCode: httpConstants.HTTP_STATUS_NOT_FOUND,
       details: params.details,
+      cause: params.cause
     })
   }
 }
@@ -61,6 +61,7 @@ export class AuthFailedError extends PublicNonRecoverableError {
       errorCode: 'AUTH_FAILED',
       httpStatusCode: httpConstants.HTTP_STATUS_UNAUTHORIZED,
       details: params.details,
+      cause: params.cause
     })
   }
 }

--- a/src/errors/publicErrors.ts
+++ b/src/errors/publicErrors.ts
@@ -37,7 +37,7 @@ export class AccessDeniedError extends PublicNonRecoverableError {
       errorCode: 'ACCESS_DENIED',
       httpStatusCode: httpConstants.HTTP_STATUS_FORBIDDEN,
       details: params.details,
-      cause: params.cause
+      cause: params.cause,
     })
   }
 }
@@ -49,7 +49,7 @@ export class EntityNotFoundError extends PublicNonRecoverableError {
       errorCode: 'ENTITY_NOT_FOUND',
       httpStatusCode: httpConstants.HTTP_STATUS_NOT_FOUND,
       details: params.details,
-      cause: params.cause
+      cause: params.cause,
     })
   }
 }
@@ -61,7 +61,7 @@ export class AuthFailedError extends PublicNonRecoverableError {
       errorCode: 'AUTH_FAILED',
       httpStatusCode: httpConstants.HTTP_STATUS_UNAUTHORIZED,
       details: params.details,
-      cause: params.cause
+      cause: params.cause,
     })
   }
 }


### PR DESCRIPTION
This PR adds an optional passing of previous error as `cause` field (see https://nodejs.org/api/errors.html#errorcause) to allow to chain errors and keep original traces in case of re-wrapping.