### PR TITLE
Add isLevelEnabled to common logger interface

### DIFF
--- a/src/logging/commonLogger.ts
+++ b/src/logging/commonLogger.ts
@@ -1,5 +1,19 @@
 import type { BaseLogger, Bindings, ChildLoggerOptions } from 'pino'
 
 export type CommonLogger = BaseLogger & {
+  /**
+   * Creates a child logger, setting all key-value pairs in `bindings` as properties in the log lines. All serializers will be applied to the given pair.
+   * Child loggers use the same output stream as the parent and inherit the current log level of the parent at the time they are spawned.
+   * If a `level` property is present in the object passed to `child` it will override the child logger level.
+   *
+   * @param bindings: an object of key-value pairs to include in log lines as properties.
+   * @param options: an options object that will override child logger inherited options.
+   * @returns a child logger instance.
+   */
   child(bindings: Bindings, options?: ChildLoggerOptions): CommonLogger
+
+  /**
+   * A utility method for determining if a given log level will write to the destination.
+   */
+  isLevelEnabled(level: string): boolean
 }


### PR DESCRIPTION
## Changes

We rely on this method in bg-jobs-common lib, would be nice to have on a common interface.

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
