### PR TITLE
Add functions for checksums and streams

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -111,3 +111,6 @@ export {
 export { waitAndRetry } from './src/utils/waitUtils'
 
 export * from './src/observability/observabilityTypes'
+
+export * from './src/utils/checksumUtils'
+export * from './src/utils/streamUtils'

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.8",
+    "@types/tmp": "^0.2.6",
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0",
     "@vitest/coverage-v8": "1.6.0",
@@ -51,6 +52,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-vitest": "0.4.1",
     "prettier": "^3.2.5",
+    "tmp": "^0.2.3",
     "typescript": "^5.4.5",
     "vitest": "1.6.0"
   }

--- a/src/utils/checksumUtils.spec.ts
+++ b/src/utils/checksumUtils.spec.ts
@@ -1,0 +1,48 @@
+import { Readable } from 'node:stream'
+
+import {
+  generateChecksumForBufferOrString,
+  generateChecksumForObject,
+  generateChecksumForReadable,
+} from './checksumUtils'
+
+const testObject = {
+  someField: 123,
+  someOtherField: 'ferfref',
+  nestedField: {
+    level2: {
+      level3: {
+        level4: {
+          value: 'some string',
+        },
+      },
+    },
+  },
+}
+
+describe('checksumUtils', () => {
+  describe('generateChecksumForBufferOrString', () => {
+    it('generates checksum', () => {
+      const checksum = generateChecksumForBufferOrString(Buffer.from('some test string value'))
+
+      expect(checksum).toBe('bfd5bbd64f6b83abe1d7d3b06221eb3a')
+    })
+  })
+
+  describe('generateChecksumForObject', () => {
+    it('generates checksum', () => {
+      const checksum = generateChecksumForObject(testObject)
+
+      expect(checksum).toBe('9d15391c6fea84d122e0b22f7b9eb90f')
+    })
+  })
+
+  describe('generateChecksumForReadable', () => {
+    it('generates checksum', async () => {
+      const readable = Readable.from(JSON.stringify(testObject))
+      const checksum = await generateChecksumForReadable(readable)
+
+      expect(checksum).toBe('9d15391c6fea84d122e0b22f7b9eb90f')
+    })
+  })
+})

--- a/src/utils/checksumUtils.ts
+++ b/src/utils/checksumUtils.ts
@@ -1,0 +1,33 @@
+import type { BinaryLike } from 'node:crypto'
+import { createHash } from 'node:crypto'
+import type { Readable } from 'node:stream'
+
+const HASH_ALGORITHM = 'md5'
+
+export function generateChecksumForBufferOrString(data: BinaryLike): string {
+  return createHash(HASH_ALGORITHM).update(data).digest('hex')
+}
+
+export function generateChecksumForObject(object: object): string {
+  const objectAsString = JSON.stringify(object)
+  return generateChecksumForBufferOrString(objectAsString)
+}
+
+export function generateChecksumForReadable(readable: Readable): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hashCreator = createHash(HASH_ALGORITHM)
+    readable.on('data', function (data) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      hashCreator.update(Buffer.from(data))
+    })
+
+    readable.on('end', function () {
+      const hash = hashCreator.digest('hex')
+      resolve(hash)
+    })
+    readable.on('error', function (err) {
+      /* c8 ignore next 1 */
+      reject(err)
+    })
+  })
+}

--- a/src/utils/checksumUtils.ts
+++ b/src/utils/checksumUtils.ts
@@ -17,8 +17,12 @@ export function generateChecksumForReadable(readable: Readable): Promise<string>
   return new Promise((resolve, reject) => {
     const hashCreator = createHash(HASH_ALGORITHM)
     readable.on('data', function (data) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      hashCreator.update(Buffer.from(data))
+      if (Buffer.isBuffer(data)) {
+        hashCreator.update(data)
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        hashCreator.update(Buffer.from(data))
+      }
     })
 
     readable.on('end', function () {

--- a/src/utils/streamUtils.spec.ts
+++ b/src/utils/streamUtils.spec.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'node:stream'
 
 import tmp from 'tmp'
-import { expect } from 'vitest'
+import { afterEach, expect } from 'vitest'
 
 import { generateChecksumForReadable } from './checksumUtils'
 import { FsReadableProvider, getReadableContentLength } from './streamUtils'
@@ -21,71 +21,64 @@ const testObject = {
 }
 
 describe('streamUtils', () => {
-  describe('persistReadableToFs', () => {
-    it('can create extra readables after persisting', async () => {
+  describe('FsReadableProvider', () => {
+    let provider: FsReadableProvider
+    beforeEach(async () => {
       const sourceReadable = Readable.from(JSON.stringify(testObject))
       const targetFile = tmp.tmpNameSync()
 
-      const provider = await FsReadableProvider.persistReadableToFs({
+      provider = await FsReadableProvider.persistReadableToFs({
         sourceReadable,
         targetFile: targetFile,
       })
-
-      const newReadable = await provider.createStream()
-      const newReadableChecksum = await generateChecksumForReadable(newReadable)
-      expect(newReadableChecksum).toBe('9d15391c6fea84d122e0b22f7b9eb90f')
-
-      const newReadable2 = await provider.createStream()
-      const newReadableChecksum2 = await generateChecksumForReadable(newReadable2)
-      expect(newReadableChecksum2).toBe('9d15391c6fea84d122e0b22f7b9eb90f')
     })
-  })
 
-  describe('destroy', () => {
-    it('deletes the file', async () => {
-      expect.assertions(4)
-      const sourceReadable = Readable.from(JSON.stringify(testObject))
-      const targetFile = tmp.tmpNameSync()
-
-      const provider = await FsReadableProvider.persistReadableToFs({
-        sourceReadable,
-        targetFile: targetFile,
-      })
-
-      expect(await provider.fileExists()).toBe(true)
+    afterEach(async () => {
       await provider.destroy()
-      expect(await provider.fileExists()).toBe(false)
-
-      try {
-        await provider.createStream()
-      } catch (err) {
-        expect((err as Error).message).toMatch(/was already deleted/)
-      }
-
-      try {
-        await provider.getContentLength()
-      } catch (err) {
-        expect((err as Error).message).toMatch(/was already deleted/)
-      }
     })
-  })
 
-  describe('getContentLength', () => {
-    it('returns length of the persisted data', async () => {
-      const sourceReadable = Readable.from(JSON.stringify(testObject))
-      const targetFile = tmp.tmpNameSync()
+    describe('persistReadableToFs', () => {
+      it('can create extra readables after persisting', async () => {
+        const newReadable = await provider.createStream()
+        const newReadableChecksum = await generateChecksumForReadable(newReadable)
+        expect(newReadableChecksum).toBe('9d15391c6fea84d122e0b22f7b9eb90f')
 
-      const provider = await FsReadableProvider.persistReadableToFs({
-        sourceReadable,
-        targetFile: targetFile,
+        const newReadable2 = await provider.createStream()
+        const newReadableChecksum2 = await generateChecksumForReadable(newReadable2)
+        expect(newReadableChecksum2).toBe('9d15391c6fea84d122e0b22f7b9eb90f')
       })
+    })
 
-      const fileContentLength = await provider.getContentLength()
-      const newReadable = await provider.createStream()
-      const readableLength = await getReadableContentLength(newReadable)
+    describe('destroy', () => {
+      it('deletes the file', async () => {
+        expect.assertions(4)
+        expect(await provider.fileExists()).toBe(true)
+        await provider.destroy()
+        expect(await provider.fileExists()).toBe(false)
 
-      expect(fileContentLength).toBe(115)
-      expect(readableLength).toBe(115)
+        try {
+          await provider.createStream()
+        } catch (err) {
+          expect((err as Error).message).toMatch(/was already deleted/)
+        }
+
+        try {
+          await provider.getContentLength()
+        } catch (err) {
+          expect((err as Error).message).toMatch(/was already deleted/)
+        }
+      })
+    })
+
+    describe('getContentLength', () => {
+      it('returns length of the persisted data', async () => {
+        const fileContentLength = await provider.getContentLength()
+        const newReadable = await provider.createStream()
+        const readableLength = await getReadableContentLength(newReadable)
+
+        expect(fileContentLength).toBe(115)
+        expect(readableLength).toBe(115)
+      })
     })
   })
 })

--- a/src/utils/streamUtils.spec.ts
+++ b/src/utils/streamUtils.spec.ts
@@ -1,0 +1,66 @@
+import { Readable } from 'node:stream'
+
+import tmp from 'tmp'
+import { expect } from 'vitest'
+
+import { generateChecksumForReadable } from './checksumUtils'
+import { FsReadableProvider } from './streamUtils'
+
+const testObject = {
+  someField: 123,
+  someOtherField: 'ferfref',
+  nestedField: {
+    level2: {
+      level3: {
+        level4: {
+          value: 'some string',
+        },
+      },
+    },
+  },
+}
+
+describe('streamUtils', () => {
+  describe('persistReadableToFs', () => {
+    it('can create extra readables after persisting', async () => {
+      const sourceReadable = Readable.from(JSON.stringify(testObject))
+      const targetFile = tmp.tmpNameSync()
+
+      const provider = await FsReadableProvider.persistReadableToFs({
+        sourceReadable,
+        targetFile: targetFile,
+      })
+
+      const newReadable = await provider.createStream()
+      const newReadableChecksum = await generateChecksumForReadable(newReadable)
+      expect(newReadableChecksum).toBe('9d15391c6fea84d122e0b22f7b9eb90f')
+
+      const newReadable2 = await provider.createStream()
+      const newReadableChecksum2 = await generateChecksumForReadable(newReadable2)
+      expect(newReadableChecksum2).toBe('9d15391c6fea84d122e0b22f7b9eb90f')
+    })
+  })
+
+  describe('destroy', () => {
+    it('deletes the file', async () => {
+      expect.assertions(3)
+      const sourceReadable = Readable.from(JSON.stringify(testObject))
+      const targetFile = tmp.tmpNameSync()
+
+      const provider = await FsReadableProvider.persistReadableToFs({
+        sourceReadable,
+        targetFile: targetFile,
+      })
+
+      expect(await provider.fileExists()).toBe(true)
+      await provider.destroy()
+      expect(await provider.fileExists()).toBe(false)
+
+      try {
+        await provider.createStream()
+      } catch (err) {
+        expect((err as Error).message).toMatch(/was already deleted/)
+      }
+    })
+  })
+})

--- a/src/utils/streamUtils.ts
+++ b/src/utils/streamUtils.ts
@@ -1,0 +1,70 @@
+import { F_OK } from 'node:constants'
+import { createWriteStream, createReadStream, access } from 'node:fs'
+import { unlink } from 'node:fs/promises'
+import type { Readable } from 'node:stream'
+import { pipeline } from 'node:stream'
+
+export type ReadableProvider = {
+  createStream(): Readable
+  destroy(): Promise<void>
+}
+
+export type PersistToFsOptions = {
+  targetFile: string
+  sourceReadable: Readable
+}
+
+export type FsReadableProviderOptions = {
+  storageFile: string
+}
+
+export class FsReadableProvider implements ReadableProvider {
+  public readonly storageFile: string
+  constructor(options: FsReadableProviderOptions) {
+    this.storageFile = options.storageFile
+  }
+
+  fileExists(): Promise<boolean> {
+    return new Promise((resolve) => {
+      access(this.storageFile, F_OK, (err) => {
+        return resolve(!err)
+      })
+    })
+  }
+
+  async createStream(): Promise<Readable> {
+    if (!(await this.fileExists())) {
+      throw new Error(`File ${this.storageFile} was already deleted.`)
+    }
+
+    return createReadStream(this.storageFile)
+  }
+
+  destroy(): Promise<void> {
+    return unlink(this.storageFile)
+  }
+
+  protected async persist(sourceReadable: Readable): Promise<void> {
+    const writable = createWriteStream(this.storageFile)
+    return new Promise((resolve, reject) => {
+      pipeline(sourceReadable, writable, (err) => {
+        if (err) {
+          /* c8 ignore next 1 */
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  public static async persistReadableToFs(
+    options: PersistToFsOptions,
+  ): Promise<FsReadableProvider> {
+    const provider = new FsReadableProvider({
+      storageFile: options.targetFile,
+    })
+    await provider.persist(options.sourceReadable)
+    return provider
+  }
+}

--- a/src/utils/streamUtils.ts
+++ b/src/utils/streamUtils.ts
@@ -60,7 +60,12 @@ export class FsReadableProvider implements ReadableProvider {
     return createReadStream(this.storageFile)
   }
 
-  destroy(): Promise<void> {
+  async destroy(): Promise<void> {
+    if (!(await this.fileExists())) {
+      // nothing to do here
+      return
+    }
+
     return unlink(this.storageFile)
   }
 

--- a/src/utils/streamUtils.ts
+++ b/src/utils/streamUtils.ts
@@ -1,11 +1,23 @@
 import { F_OK } from 'node:constants'
 import { createWriteStream, createReadStream, access } from 'node:fs'
-import { unlink } from 'node:fs/promises'
+import { stat, unlink } from 'node:fs/promises'
 import type { Readable } from 'node:stream'
 import { pipeline } from 'node:stream'
 
 export type ReadableProvider = {
-  createStream(): Readable
+  /**
+   * Guarantees to provide a new stream every time this is called, before `destroy` is invoked.
+   */
+  createStream(): Promise<Readable>
+
+  /**
+   * Returns size of the persisted content
+   */
+  getContentLength(): Promise<number>
+
+  /**
+   * Remove the persisted value. No new streams can be created after this is called
+   */
   destroy(): Promise<void>
 }
 
@@ -30,6 +42,14 @@ export class FsReadableProvider implements ReadableProvider {
         return resolve(!err)
       })
     })
+  }
+
+  async getContentLength(): Promise<number> {
+    if (!(await this.fileExists())) {
+      throw new Error(`File ${this.storageFile} was already deleted.`)
+    }
+    const stats = await stat(this.storageFile)
+    return stats.size
   }
 
   async createStream(): Promise<Readable> {
@@ -67,4 +87,22 @@ export class FsReadableProvider implements ReadableProvider {
     await provider.persist(options.sourceReadable)
     return provider
   }
+}
+
+export function getReadableContentLength(readable: Readable): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let size = 0
+    readable.on('data', (chunk) => {
+      if (typeof chunk === 'string' || Buffer.isBuffer(chunk)) {
+        size += Buffer.byteLength(chunk)
+      }
+    })
+    readable.on('end', () => {
+      resolve(size)
+    })
+    readable.on('error', (error) => {
+      /* c8 ignore next 1 */
+      reject(error)
+    })
+  })
 }


### PR DESCRIPTION
## Changes

Provides functions for persisting streams for multiple reuses in the future, and for the ease of the content-length calculation

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [ ] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
