### PR TITLE
MET-160 Add Redis keyPrefix to be used instead of db

### DIFF
--- a/src/config/configTypes.ts
+++ b/src/config/configTypes.ts
@@ -6,7 +6,8 @@ export type RedisConfig = {
   /**
    * An integer from 0 to 15, inclusive
    */
-  db: number
+  db?: number
+  keyPrefix?: string
   port: number
   username?: string
   password?: string


### PR DESCRIPTION
## Changes

In new services we want to start using `keyPrefix` instead of `db` for isolation.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
