### PR TITLE
update errors cause param type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,11 @@
 
 Core libraries for Node.js backend services.
 
-- [Overview](#overview)
-- [HTTP Client](#http-client)
 - [Default Logging Configuration](#default-logging-configuration)
 - [ConfigScope](#configscope)
 - [Error Handling](#error-handling)
 
 See [docs](/docs) for further instructions on how to use.
-
-## Overview
 
 ## Default Logging Configuration
 
@@ -136,11 +132,13 @@ The library exposes classes for the following errors:
 - `InternalError`, which issues a `500` status code and is not exposed in the global error handler. It expects the following parameters:
   - `message`;
   - `errorCode`;
-  - `details` – (optional).
+  - `details` – (optional);
+  - `cause` – (optional).
 - `PublicNonRecoverableError`, which issues the HTTP status code provided and signals that the user did something wrong, hence the error is returned to the consumer of the API. It expects the following parameters:
   - `message`;
   - `errorCode`;
   - `details` – (optional);
+  - `cause` – (optional);
   - `httpStatusCode` – (optional). Defaults to `500`;
 
 ### Either

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+export type { ErrorDetails } from './src/errors/types'
+
 export {
   PublicNonRecoverableError,
   type PublicNonRecoverableErrorParams,
@@ -5,7 +7,6 @@ export {
 
 export {
   InternalError,
-  type ErrorDetails,
   type InternalErrorParams,
 } from './src/errors/InternalError'
 export { isEntityGoneError } from './src/errors/errorTypeGuards'

--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -1,10 +1,10 @@
-export type ErrorDetails = Record<string, unknown>
+import type { ErrorDetails } from './types';
 
 export type InternalErrorParams<T = ErrorDetails> = {
   message: string
   errorCode: string
   details?: T
-  cause?: Error
+  cause?: unknown
 }
 
 export class InternalError<T = ErrorDetails> extends Error {

--- a/src/errors/PublicNonRecoverableError.ts
+++ b/src/errors/PublicNonRecoverableError.ts
@@ -1,22 +1,22 @@
-import type { ErrorDetails } from './InternalError'
+import type { ErrorDetails } from './types';
 
-export type PublicNonRecoverableErrorParams = {
+export type PublicNonRecoverableErrorParams<T = ErrorDetails> = {
   message: string
   errorCode: string
-  details?: ErrorDetails
+  details?: T
   httpStatusCode?: number
-  cause?: Error
+  cause?: unknown
 }
 
 /**
  * This error is returned to the consumer of API
  */
-export class PublicNonRecoverableError extends Error {
-  public readonly details?: ErrorDetails
+export class PublicNonRecoverableError<T = ErrorDetails> extends Error {
+  public readonly details?: T
   public readonly errorCode: string
   public readonly httpStatusCode: number
 
-  constructor(params: PublicNonRecoverableErrorParams) {
+  constructor(params: PublicNonRecoverableErrorParams<T>) {
     super(params.message, {
       cause: params.cause,
     })

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -1,0 +1,1 @@
+export type ErrorDetails = Record<string, unknown>


### PR DESCRIPTION
## Changes

- change Internal and Public error `cause` type to `unknown`
- add generic for PublicError (to be consistent with InternalError) - it will be breaking for any `if (err instanceof 
- update Readme with cause param

## Migration guide

Any instanceof check for PublicNonRecoverableError has to be modified (applies only if isPublicNonRecoverableError wasn't used). Please change:
```
if (err instanceof PublicNonRecoverableError) { ... }
```
into
```
if (err instanceof PublicNonRecoverableError<unknown>) { ... }
```

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
