### PR TITLE
Adding wasSuccessful param to TransactionObservabilityManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,7 @@
         "url": "git://github.com/lokalise/node-core.git"
     },
     "license": "Apache-2.0",
-    "files": [
-        "dist/**",
-        "LICENSE",
-        "README.md"
-    ],
+    "files": ["dist/**", "LICENSE", "README.md"],
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "lint": "biome check . && tsc --project tsconfig.lint.json --noEmit",
         "lint:fix": "biome check --write",
         "version": "auto-changelog -p && git add CHANGELOG.md",
-        "prepublishOnly": "npm run build"
+        "prepublishOnly": "npm run build",
+        "postversion": "biome check --write package.json"
     },
     "dependencies": {
         "dot-prop": "6.0.1",

--- a/src/observability/observabilityTypes.ts
+++ b/src/observability/observabilityTypes.ts
@@ -23,6 +23,7 @@ export type TransactionObservabilityManager = {
   /**
    * Ends the transaction
    * @param uniqueTransactionKey - used for identifying specific ongoing transaction. Must be reasonably unique to reduce possibility of collisions
+   * @param wasSuccessful - indicates if the transaction was successful or not
    */
-  stop: (uniqueTransactionKey: string) => unknown
+  stop: (uniqueTransactionKey: string, wasSuccessful?: boolean) => unknown
 }


### PR DESCRIPTION
For some transaction observability tools, might be beneficial to know if a transaction was successful or not, improving API to support it

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
