### PR TITLE
AP-5015 added maxRetriesPerRequest to RedisConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,7 @@
         "url": "git://github.com/lokalise/node-core.git"
     },
     "license": "Apache-2.0",
-    "files": [
-        "dist/**",
-        "LICENSE",
-        "README.md"
-    ],
+    "files": ["dist/**", "LICENSE", "README.md"],
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "commonjs",

--- a/src/config/configTypes.ts
+++ b/src/config/configTypes.ts
@@ -13,6 +13,7 @@ export type RedisConfig = {
   password?: string
   commandTimeout?: number
   connectTimeout?: number
+  maxRetriesPerRequest?: number | null
   useTls: boolean
 }
 

--- a/src/config/configTypes.ts
+++ b/src/config/configTypes.ts
@@ -14,6 +14,8 @@ export type RedisConfig = {
   commandTimeout?: number
   connectTimeout?: number
   maxRetriesPerRequest?: number | null
+  enableReadyCheck?: boolean
+  lazyConnect?: boolean
   useTls: boolean
 }
 

--- a/src/config/configTypes.ts
+++ b/src/config/configTypes.ts
@@ -13,6 +13,10 @@ export type RedisConfig = {
   password?: string
   commandTimeout?: number
   connectTimeout?: number
+  /**
+   * Set this option explicitly to null for infinite retries
+   * By default (for undefined) there are 20 retries, see: https://redis.github.io/ioredis/interfaces/CommonRedisOptions.html#maxRetriesPerRequest
+   */
   maxRetriesPerRequest?: number | null
   enableReadyCheck?: boolean
   lazyConnect?: boolean


### PR DESCRIPTION
## Changes

Adding maxRetriesPerRequest parameter to RedisConfig, so that it can be used in default configuration object. 
See: https://lokalise.atlassian.net/browse/AP-5015

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
