### PR TITLE
AP-5078 MultiTransactionObservabilityManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,7 @@
         "url": "git://github.com/lokalise/node-core.git"
     },
     "license": "Apache-2.0",
-    "files": [
-        "dist/**",
-        "LICENSE",
-        "README.md"
-    ],
+    "files": ["dist/**", "LICENSE", "README.md"],
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "commonjs",

--- a/src/observability/MultiTransactionObservabilityManager.spec.ts
+++ b/src/observability/MultiTransactionObservabilityManager.spec.ts
@@ -1,0 +1,66 @@
+import { MultiTransactionObservabilityManager } from './MultiTransactionObservabilityManager'
+import type { TransactionObservabilityManager } from './observabilityTypes'
+
+describe('MultiTransactionObservabilityManager', () => {
+  let multiTransactionObservabilityManager: MultiTransactionObservabilityManager
+  let fakeTransactionManager1: FakeTransactionManager
+  let fakeTransactionManager2: FakeTransactionManager
+
+  beforeAll(() => {
+    fakeTransactionManager1 = new FakeTransactionManager()
+    fakeTransactionManager2 = new FakeTransactionManager()
+    multiTransactionObservabilityManager = new MultiTransactionObservabilityManager([
+      fakeTransactionManager1,
+      fakeTransactionManager2,
+    ])
+  })
+
+  it('throws error on constructor if list is empty', () => {
+    expect(() => new MultiTransactionObservabilityManager([])).toThrowError(
+      'At least one manager must be provided',
+    )
+  })
+
+  it('start is being called on all managers', () => {
+    const spy1 = vi.spyOn(fakeTransactionManager1, 'start')
+    const spy2 = vi.spyOn(fakeTransactionManager2, 'start')
+
+    multiTransactionObservabilityManager.start('transactionName', 'uniqueTransactionKey')
+
+    expect(spy1).toHaveBeenCalledWith('transactionName', 'uniqueTransactionKey')
+    expect(spy2).toHaveBeenCalledWith('transactionName', 'uniqueTransactionKey')
+  })
+
+  it('startWithGroup is being called on all managers', () => {
+    const spy1 = vi.spyOn(fakeTransactionManager1, 'startWithGroup')
+    const spy2 = vi.spyOn(fakeTransactionManager2, 'startWithGroup')
+
+    multiTransactionObservabilityManager.startWithGroup(
+      'transactionName',
+      'uniqueTransactionKey',
+      'group',
+    )
+
+    expect(spy1).toHaveBeenCalledWith('transactionName', 'uniqueTransactionKey', 'group')
+    expect(spy2).toHaveBeenCalledWith('transactionName', 'uniqueTransactionKey', 'group')
+  })
+
+  it.each([undefined, false, true])(
+    'stop is being called on all managers, wasSuccessful: %s',
+    (wasSuccessful) => {
+      const spy1 = vi.spyOn(fakeTransactionManager1, 'stop')
+      const spy2 = vi.spyOn(fakeTransactionManager2, 'stop')
+
+      multiTransactionObservabilityManager.stop('uniqueTransactionKey', wasSuccessful)
+
+      expect(spy1).toHaveBeenCalledWith('uniqueTransactionKey', wasSuccessful)
+      expect(spy2).toHaveBeenCalledWith('uniqueTransactionKey', wasSuccessful)
+    },
+  )
+})
+
+class FakeTransactionManager implements TransactionObservabilityManager {
+  start(): void {}
+  startWithGroup(): void {}
+  stop(): void {}
+}

--- a/src/observability/MultiTransactionObservabilityManager.spec.ts
+++ b/src/observability/MultiTransactionObservabilityManager.spec.ts
@@ -15,12 +15,6 @@ describe('MultiTransactionObservabilityManager', () => {
     ])
   })
 
-  it('throws error on constructor if list is empty', () => {
-    expect(() => new MultiTransactionObservabilityManager([])).toThrowError(
-      'At least one manager must be provided',
-    )
-  })
-
   it('start is being called on all managers', () => {
     const spy1 = vi.spyOn(fakeTransactionManager1, 'start')
     const spy2 = vi.spyOn(fakeTransactionManager2, 'start')

--- a/src/observability/MultiTransactionObservabilityManager.ts
+++ b/src/observability/MultiTransactionObservabilityManager.ts
@@ -1,5 +1,9 @@
 import type { TransactionObservabilityManager } from './observabilityTypes'
 
+/**
+ * Groups different TransactionObservabilityManager instances into one
+ * to facilitate tracking transactions across multiple observability systems.
+ */
 export class MultiTransactionObservabilityManager implements TransactionObservabilityManager {
   private readonly managers: TransactionObservabilityManager[]
 

--- a/src/observability/MultiTransactionObservabilityManager.ts
+++ b/src/observability/MultiTransactionObservabilityManager.ts
@@ -4,7 +4,6 @@ export class MultiTransactionObservabilityManager implements TransactionObservab
   private readonly managers: TransactionObservabilityManager[]
 
   constructor(managers: TransactionObservabilityManager[]) {
-    if (managers.length === 0) throw new Error('At least one manager must be provided')
     this.managers = managers
   }
 

--- a/src/observability/MultiTransactionObservabilityManager.ts
+++ b/src/observability/MultiTransactionObservabilityManager.ts
@@ -2,7 +2,7 @@ import type { TransactionObservabilityManager } from './observabilityTypes'
 
 /**
  * Groups different TransactionObservabilityManager instances into one
- * to facilitate tracking transactions across multiple observability systems.
+ * to facilitate tracking transactions across multiple observability tools.
  */
 export class MultiTransactionObservabilityManager implements TransactionObservabilityManager {
   private readonly managers: TransactionObservabilityManager[]

--- a/src/observability/MultiTransactionObservabilityManager.ts
+++ b/src/observability/MultiTransactionObservabilityManager.ts
@@ -1,0 +1,32 @@
+import type { TransactionObservabilityManager } from './observabilityTypes'
+
+export class MultiTransactionObservabilityManager implements TransactionObservabilityManager {
+  private readonly managers: TransactionObservabilityManager[]
+
+  constructor(managers: TransactionObservabilityManager[]) {
+    if (managers.length === 0) throw new Error('At least one manager must be provided')
+    this.managers = managers
+  }
+
+  start(transactionName: string, uniqueTransactionKey: string): void {
+    for (const manager of this.managers) {
+      manager.start(transactionName, uniqueTransactionKey)
+    }
+  }
+
+  startWithGroup(
+    transactionName: string,
+    uniqueTransactionKey: string,
+    transactionGroup: string,
+  ): void {
+    for (const manager of this.managers) {
+      manager.startWithGroup(transactionName, uniqueTransactionKey, transactionGroup)
+    }
+  }
+
+  stop(uniqueTransactionKey: string, wasSuccessful?: boolean): void {
+    for (const manager of this.managers) {
+      manager.stop(uniqueTransactionKey, wasSuccessful)
+    }
+  }
+}


### PR DESCRIPTION
## Changes

Adding `MultiTransactionObservabilityManager` to facilitate grouping different managers

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
