### PR TITLE
Unpin a specific version of @vitest/coverage-v8 and vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
         "@lokalise/biome-config": "^1.3.0",
         "@types/node": "^22.5.2",
         "@types/tmp": "^0.2.6",
-        "@vitest/coverage-v8": "2.0.5",
+        "@vitest/coverage-v8": "^2.0.5",
         "auto-changelog": "^2.4.0",
         "pino-test": "^1.0.1",
         "tmp": "^0.2.3",
         "typescript": "^5.5.3",
-        "vitest": "2.0.5"
+        "vitest": "^2.0.5"
     }
 }


### PR DESCRIPTION
## Changes

Unpin @vitest/coverage-v8 and vitest from 2.0.5 specifically.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
