### PR TITLE
fix dual publish package entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "license": "Apache-2.0",
     "files": ["dist"],
     "type": "module",
+    "main": "./dist/index.js",
     "exports": {
         "./package.json": "./package.json",
         ".": {


### PR DESCRIPTION
## Changes

Sets the package entry point so it works well for CJS and ESM.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
