### PR TITLE
hide error symbol from being printed

### DIFF
--- a/src/errors/InternalError.spec.ts
+++ b/src/errors/InternalError.spec.ts
@@ -1,3 +1,4 @@
+import { stdSerializers } from 'pino'
 import { InternalError, isInternalError } from './InternalError'
 
 describe('InternalError', () => {
@@ -17,7 +18,16 @@ describe('InternalError', () => {
       expect(isInternalError(err)).toBe(true)
     })
 
-    it('detects if error is public for extended error', () => {
+    it('does not expose INTERNAL_ERROR_KEY symbol', () => {
+      const err = new InternalError({
+        message: 'Unknown',
+        errorCode: 'INTERNAL_ERROR',
+      })
+
+      expect(stdSerializers.err(err)).not.toHaveProperty('Symbol(INTERNAL_ERROR_KEY)')
+    })
+
+    it('detects if error is internal for extended error', () => {
       class ExtendedInternalError extends InternalError {
         constructor() {
           super({

--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -1,4 +1,4 @@
-import { isError } from '../utils/typeUtils'
+import { isNativeError } from 'node:util/types'
 import type { ErrorDetails } from './types'
 
 export type InternalErrorParams<T = ErrorDetails> = {
@@ -8,11 +8,9 @@ export type InternalErrorParams<T = ErrorDetails> = {
   cause?: unknown
 }
 
-const INTERNAL_ERROR_SYMBOL_KEY = 'INTERNAL_ERROR_KEY'
-const internalErrorSymbol = Symbol.for(INTERNAL_ERROR_SYMBOL_KEY)
+const INTERNAL_ERROR_SYMBOL = Symbol.for('INTERNAL_ERROR_KEY')
 
 export class InternalError<T = ErrorDetails> extends Error {
-  readonly [internalErrorSymbol] = true
   public readonly details?: T
   public readonly errorCode: string
 
@@ -27,11 +25,14 @@ export class InternalError<T = ErrorDetails> extends Error {
   }
 }
 
+Object.defineProperty(InternalError.prototype, INTERNAL_ERROR_SYMBOL, {
+  value: true,
+})
+
 export function isInternalError(error: unknown): error is InternalError {
   return (
-    isError(error) &&
+    isNativeError(error) &&
     // biome-ignore lint/suspicious/noExplicitAny: checking for existence of prop outside or Error interface
-    ((error as any)[Symbol.for(INTERNAL_ERROR_SYMBOL_KEY)] === true ||
-      error.name === 'InternalError')
+    ((error as any)[INTERNAL_ERROR_SYMBOL] === true || error.name === 'InternalError')
   )
 }

--- a/src/errors/PublicNonRecoverableError.spec.ts
+++ b/src/errors/PublicNonRecoverableError.spec.ts
@@ -1,3 +1,4 @@
+import { stdSerializers } from 'pino'
 import { PublicNonRecoverableError, isPublicNonRecoverableError } from './PublicNonRecoverableError'
 
 describe('PublicNonRecoverableError', () => {
@@ -24,6 +25,15 @@ describe('PublicNonRecoverableError', () => {
       })
 
       expect(isPublicNonRecoverableError(err)).toBe(true)
+    })
+
+    it('does not expose PUBLIC_NON_RECOVERABLE_ERROR_KEY symbol', () => {
+      const err = new PublicNonRecoverableError({
+        message: 'Unknown',
+        errorCode: 'PUBLIC_ERROR',
+      })
+
+      expect(stdSerializers.err(err)).not.toHaveProperty('Symbol(PUBLIC_NON_RECOVERABLE_ERROR_KEY)')
     })
 
     it('detects if error is public for extended error', () => {

--- a/src/errors/PublicNonRecoverableError.ts
+++ b/src/errors/PublicNonRecoverableError.ts
@@ -39,6 +39,6 @@ export function isPublicNonRecoverableError(error: unknown): error is PublicNonR
   return (
     isNativeError(error) &&
     // biome-ignore lint/suspicious/noExplicitAny: checking for existence of prop outside or Error interface
-    ((error as any)[PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL] === true || error.name === 'InternalError')
+    ((error as any)[PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL] === true || error.name === 'PublicNonRecoverableError')
   )
 }

--- a/src/errors/PublicNonRecoverableError.ts
+++ b/src/errors/PublicNonRecoverableError.ts
@@ -1,4 +1,4 @@
-import { isError } from '../utils/typeUtils'
+import { isNativeError } from 'node:util/types'
 import type { ErrorDetails } from './types'
 
 export type PublicNonRecoverableErrorParams<T = ErrorDetails> = {
@@ -9,14 +9,12 @@ export type PublicNonRecoverableErrorParams<T = ErrorDetails> = {
   cause?: unknown
 }
 
-const PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL_KEY = 'PUBLIC_NON_RECOVERABLE_ERROR_KEY'
-const publicNonRecoverableErrorSymbol = Symbol.for(PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL_KEY)
+const PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL = Symbol.for('PUBLIC_NON_RECOVERABLE_ERROR_KEY')
 
 /**
  * This error is returned to the consumer of API
  */
 export class PublicNonRecoverableError<T = ErrorDetails> extends Error {
-  readonly [publicNonRecoverableErrorSymbol] = true
   public readonly details?: T
   public readonly errorCode: string
   public readonly httpStatusCode: number
@@ -33,11 +31,14 @@ export class PublicNonRecoverableError<T = ErrorDetails> extends Error {
   }
 }
 
+Object.defineProperty(PublicNonRecoverableError.prototype, PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL, {
+  value: true,
+})
+
 export function isPublicNonRecoverableError(error: unknown): error is PublicNonRecoverableError {
   return (
-    isError(error) &&
+    isNativeError(error) &&
     // biome-ignore lint/suspicious/noExplicitAny: checking for existence of prop outside or Error interface
-    ((error as any)[Symbol.for(PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL_KEY)] === true ||
-      error.name === 'PublicNonRecoverableError')
+    ((error as any)[PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL] === true || error.name === 'InternalError')
   )
 }

--- a/src/errors/PublicNonRecoverableError.ts
+++ b/src/errors/PublicNonRecoverableError.ts
@@ -39,6 +39,7 @@ export function isPublicNonRecoverableError(error: unknown): error is PublicNonR
   return (
     isNativeError(error) &&
     // biome-ignore lint/suspicious/noExplicitAny: checking for existence of prop outside or Error interface
-    ((error as any)[PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL] === true || error.name === 'PublicNonRecoverableError')
+    ((error as any)[PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL] === true ||
+      error.name === 'PublicNonRecoverableError')
   )
 }


### PR DESCRIPTION
## Changes

This PR prevents the error symbol from being printed.
console.log output of the previous implementation:
![image](https://github.com/user-attachments/assets/a3d7ffe3-bc75-4a2f-b607-480e1a8fedde)

console.log output of the new implementation
![image](https://github.com/user-attachments/assets/6b6123e7-c349-45a5-bc25-226822721bf6)

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
