### PR TITLE
Add float number config validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,17 @@ Once the class is instantiated, you can leverage the following `ConfigScope` met
 
 - `getMandatory()`, returns the value of a mandatory configuration parameter. If the value is missing, an `InternalError` is thrown. Parameters are:
   - `param`, the configuration parameter name;
-- `getMandatoryInteger()`, returns the value of a mandatory configuration parameter and validates that it is a number. If the value is missing or is not a number, an `InternalError` is thrown. Parameters are:
+- `getMandatoryInteger()`, returns the value of a mandatory configuration parameter and validates that it is an integer number. If the value is missing or is not an integer, an `InternalError` is thrown. Parameters are:
+  - `param`, the configuration parameter name;
+- `getMandatoryNumber()`, returns the value of a mandatory configuration parameter and validates that it is a number. If the value is missing or is not a number, an `InternalError` is thrown. Parameters are:
   - `param`, the configuration parameter name;
 - `getMandatoryOneOf()`, returns the value a mandatory configuration parameter and validates that it is one of the supported values. If the value is missing or is not supported, an `InternalError` is thrown. The method also serves as a type guard, narrowing the type of the passed value down to one of the supported options. Parameters are:
   - `param`, the configuration parameter name;
   - `supportedValues`;
 - `getMandatoryValidatedInteger()`, similar to `getMandatoryInteger()`, but also takes a `validator` in input and will throw an `InternalError` if the number is not valid. See [Validators and Transformers](#validators-and-transformers) for more information. Parameters are:
+  - `param`, the configuration parameter name;
+  - `validator`;
+- `getMandatoryValidatedNumber()`, similar to `getMandatoryNumber()`, but also takes a `validator` in input and will throw an `InternalError` if the number is not valid. See [Validators and Transformers](#validators-and-transformers) for more information. Parameters are:
   - `param`, the configuration parameter name;
   - `validator`;
 - `getMandatoryTransformed()`, calls `getMandatory()` and returns the result of the `transformer` function applied to the configuration parameter value. See [Validators and Transformers](#validators-and-transformers) for more information. Parameters are:
@@ -71,14 +76,21 @@ Once the class is instantiated, you can leverage the following `ConfigScope` met
   - `param`, the configuration parameter name;
   - `defaultValue`, which can be nullable;
 - `getOptional()`, similar to `getOptionalNullable()`, but `defaultValue` cannot be nullable. The return value is always a string;
-- `getOptionalIntegerNullable()`, returns the value of an optional configuration parameter and validates that it is a number. If the value is missing, it is set to the provided default value. If it is not a number, an `InternalError` is thrown. Parameters are:
+- `getOptionalNullableInteger()`, returns the value of an optional configuration parameter and validates that it is an integer number. If the value is missing, it is set to the provided default value. If it is not a number, an `InternalError` is thrown. Parameters are:
   - `param`, the configuration parameter name;
   - `defaultValue`, which can be nullable;
-- `getOptionalInteger`, similar to `getOptionalIntegerNullable()`, but `defaultValue` cannot be nullable. The return value is always a number;
+- `getOptionalNullableNumber()`, returns the value of an optional configuration parameter and validates that it is a number. If the value is missing, it is set to the provided default value. If it is not a number, an `InternalError` is thrown. Parameters are:
+  - `param`, the configuration parameter name;
+  - `defaultValue`, which can be nullable;
+- `getOptionalInteger`, similar to `getOptionalNullableInteger()`, but `defaultValue` cannot be nullable. The return value is always a number;
+- `getOptionalNumber`, similar to `getOptionalNullableNumber()`, but `defaultValue` cannot be nullable. The return value is always a number;
 - `getOptionalValidated()`, similar to `getOptional()`, but also takes a `validator` in input and will throw an `InternalError` if the value is not valid. See [Validators and Transformers](#validators-and-transformers) for more information. Parameters are:
   - `param`, the configuration parameter name;
   - `validator`;
-- `getOptionalValidatedInteger()`, similar to `getOptionalValidated()`, but expects and returns `number` instead. See [Validators and Transformers](#validators-and-transformers) for more information. Parameters are:
+- `getOptionalValidatedInteger()`, similar to `getOptionalValidated()`, but expects and returns an integer `number` instead. See [Validators and Transformers](#validators-and-transformers) for more information. Parameters are:
+  - `param`, the configuration parameter name;
+  - `validator`;
+- `getOptionalValidatedNumber()`, similar to `getOptionalValidated()`, but expects and returns `number` instead. See [Validators and Transformers](#validators-and-transformers) for more information. Parameters are:
   - `param`, the configuration parameter name;
   - `validator`;
 - `getOptionalTransformed()`, similar to `getOptional()`, but also takes a `transformer` in input and the result of the `transformer` function applied to the configuration parameter value. See [Validators and Transformers](#validators-and-transformers) for more information. Parameters are:

--- a/src/config/ConfigScope.spec.ts
+++ b/src/config/ConfigScope.spec.ts
@@ -552,7 +552,6 @@ describe('ConfigScope', () => {
     })
   })
 
-
   describe('getOptionalNullableNumber', () => {
     it('accepts value', () => {
       process.env.value = '3.5'

--- a/src/config/ConfigScope.ts
+++ b/src/config/ConfigScope.ts
@@ -30,6 +30,20 @@ export class ConfigScope {
     }
     return validateNumber(
       Number.parseInt(rawValue),
+      `Configuration parameter ${param}\` must be an integer number, but was ${rawValue}`,
+    )
+  }
+
+  getMandatoryNumber(param: string): number {
+    const rawValue = this.env[param]
+    if (!rawValue) {
+      throw new InternalError({
+        message: `Missing mandatory configuration parameter: ${param}`,
+        errorCode: 'CONFIGURATION_ERROR',
+      })
+    }
+    return validateNumber(
+      Number.parseFloat(rawValue),
       `Configuration parameter ${param}\` must be a number, but was ${rawValue}`,
     )
   }
@@ -65,6 +79,17 @@ export class ConfigScope {
     return value
   }
 
+  getMandatoryValidatedNumber(param: string, validator: EnvValueValidator<number>): number {
+    const value = this.getMandatoryNumber(param)
+    if (!validator(value)) {
+      throw new InternalError({
+        message: `Value ${value} is invalid for parameter ${param}`,
+        errorCode: 'CONFIGURATION_ERROR',
+      })
+    }
+    return value
+  }
+
   getOptionalNullable<T extends string | null | undefined>(
     param: string,
     defaultValue: T,
@@ -88,6 +113,17 @@ export class ConfigScope {
     )
   }
 
+  getOptionalNumber(param: string, defaultValue: number): number {
+    const rawValue = this.env[param]
+    if (!rawValue) {
+      return defaultValue
+    }
+    return validateNumber(
+      Number.parseFloat(rawValue),
+      `Configuration parameter ${param}\` must be a number, but was ${rawValue}`,
+    )
+  }
+
   getOptionalNullableInteger<T extends number | null | undefined>(
     param: string,
     defaultValue: T,
@@ -98,6 +134,20 @@ export class ConfigScope {
     }
     return validateNumber(
       Number.parseInt(rawValue),
+      `Configuration parameter ${param}\` must be an integer number, but was ${rawValue}`,
+    )
+  }
+
+  getOptionalNullableNumber<T extends number | null | undefined>(
+    param: string,
+    defaultValue: T,
+  ): T | number {
+    const rawValue = this.env[param]
+    if (!rawValue) {
+      return defaultValue
+    }
+    return validateNumber(
+      Number.parseFloat(rawValue),
       `Configuration parameter ${param}\` must be a number, but was ${rawValue}`,
     )
   }
@@ -136,6 +186,23 @@ export class ConfigScope {
     validator: EnvValueValidator<number>,
   ): number {
     const value = this.getOptionalInteger(param, defaultValue)
+
+    if (!validator(value)) {
+      throw new InternalError({
+        message: `Value ${value} is invalid for parameter ${param}`,
+        errorCode: 'CONFIGURATION_ERROR',
+      })
+    }
+
+    return value
+  }
+
+  getOptionalValidatedNumber(
+    param: string,
+    defaultValue: number,
+    validator: EnvValueValidator<number>,
+  ): number {
+    const value = this.getOptionalNumber(param, defaultValue)
 
     if (!validator(value)) {
       throw new InternalError({


### PR DESCRIPTION
## Changes

This PR adds float number validators to be available alongside integer ones.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
