### PR TITLE
add getBySchema method to configScope

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ The library provides methods to resolve the default logging configuration. Publi
 
 Once the class is instantiated, you can leverage the following `ConfigScope` methods:
 
+### Configuration Parameters by zod schema
+
+- `getBySchema()`, uses zod schema to validate configuration parameter, the returned type is inferred from the schema
+  - `param`, the configuration parameter name;
+  - `schema`, zod schema to use for validation;
+
 ### Mandatory Configuration Parameters
 
 - `getMandatory()`, returns the value of a mandatory configuration parameter. If the value is missing, an `InternalError` is thrown. Parameters are:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Once the class is instantiated, you can leverage the following `ConfigScope` met
 
 - `getBySchema()`, uses zod schema to validate configuration parameter, the returned type is inferred from the schema
   - `param`, the configuration parameter name;
-  - `schema`, zod schema to use for validation;
+  - `schema`, zod schema to use for parsing and validation;
 
 ### Mandatory Configuration Parameters
 

--- a/src/config/ConfigScope.spec.ts
+++ b/src/config/ConfigScope.spec.ts
@@ -32,7 +32,9 @@ describe('ConfigScope', () => {
       process.env.value = '0.1'
       const configScope = new ConfigScope()
 
-      expect(() => configScope.getBySchema('value', z.coerce.number().int())).toThrowError(/Expected integer, received float/)
+      expect(() => configScope.getBySchema('value', z.coerce.number().int())).toThrowError(
+        /Expected integer, received float/,
+      )
     })
 
     it('throws when param does not fulfill url schema', () => {
@@ -46,7 +48,9 @@ describe('ConfigScope', () => {
       process.env.value = 'example'
       const configScope = new ConfigScope()
 
-      expect(() => configScope.getBySchema('value', z.enum(['dev', 'prod']))).toThrowError(/Invalid enum value. Expected 'dev' | 'prod', received 'example'/)
+      expect(() => configScope.getBySchema('value', z.enum(['dev', 'prod']))).toThrowError(
+        /Invalid enum value. Expected 'dev' | 'prod', received 'example'/,
+      )
     })
 
     it('returns undefined if value is missing and schema is optional', () => {

--- a/src/config/ConfigScope.ts
+++ b/src/config/ConfigScope.ts
@@ -20,6 +20,21 @@ export class ConfigScope {
     this.env = { ...process.env }
   }
 
+  getBySchema<T>(param: string, schema: ZodSchema<T>): T {
+    const rawValue = this.env[param]
+
+    const result = schema.safeParse(rawValue)
+
+    if (!result.success) {
+      throw new InternalError({
+        message: `Validation of configuration parameter "${param}" has failed: ${result.error.issues.at(0)?.message}`,
+        errorCode: 'CONFIGURATION_ERROR',
+      })
+    }
+
+    return result.data
+  }
+
   getMandatoryInteger(param: string): number {
     const rawValue = this.env[param]
     if (!rawValue) {

--- a/src/config/ConfigScope.ts
+++ b/src/config/ConfigScope.ts
@@ -29,6 +29,7 @@ export class ConfigScope {
       throw new InternalError({
         message: `Validation of configuration parameter "${param}" has failed: ${result.error.issues.at(0)?.message}`,
         errorCode: 'CONFIGURATION_ERROR',
+        cause: result.error,
       })
     }
 


### PR DESCRIPTION
## Changes

This PR adds `getBySchema` method that allows using zod schema to perform envvar validation.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
