### PR TITLE
Add JSON-based log for serializing arbitrary values into an explicit string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,8 @@ export {
 export type { AppLoggerConfig, MonorepoAppLoggerConfig } from './logging/loggerConfigResolver'
 export type { CommonLogger } from './logging/commonLogger'
 
+export { stringValueSerializer } from './logging/stringValueSerializer'
+
 export type {
   ErrorReport,
   ErrorReporter,

--- a/src/logging/stringValueSerializer.spec.ts
+++ b/src/logging/stringValueSerializer.spec.ts
@@ -1,0 +1,9 @@
+import { stringValueSerializer } from './stringValueSerializer'
+
+describe('stringValueSerializer', () => {
+  it('adds extra quotes around serialized value', () => {
+    expect(stringValueSerializer({ foo: 'bar' })).toBe('"{"foo":"bar"}"')
+    expect(stringValueSerializer('test')).toBe('""test""')
+    expect(stringValueSerializer(null)).toBe('"null"')
+  })
+})

--- a/src/logging/stringValueSerializer.ts
+++ b/src/logging/stringValueSerializer.ts
@@ -1,0 +1,6 @@
+/**
+ * Serializes the given value into a JSON string and explicitly wraps it in double quotes.
+ * This ensures that log collectors (like Graylog) treat it as a string and not as a JSON object,
+ * preventing the automatic extraction of properties that could lead to property explosion.
+ */
+export const stringValueSerializer = (value: unknown) => `"${JSON.stringify(value)}"`


### PR DESCRIPTION
## Changes

Add JSON-based serializer that wraps values in quotes to prevent unwrapping by log collectors like Graylog

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
