### PR TITLE
Reapply "feat: improve error details typesafety"

### DIFF
--- a/src/config/ConfigScope.ts
+++ b/src/config/ConfigScope.ts
@@ -317,7 +317,7 @@ export class ConfigScope {
       throw new InternalError({
         message: errorMessage,
         errorCode: 'CONFIGURATION_ERROR',
-        details: parsedValue.error,
+        details: parsedValue.error as unknown as Record<string, unknown>,
       })
     }
 

--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -1,11 +1,5 @@
 import { isNativeError } from 'node:util/types'
-import type { ErrorDetails } from './types'
-
-type BaseErrorParams = {
-  message: string
-  errorCode: string
-  cause?: unknown
-}
+import type { BaseErrorParams, ErrorDetails } from './types'
 
 export type InternalErrorParams<T> = T extends undefined
   ? BaseErrorParams

--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -9,7 +9,9 @@ export type InternalErrorParams<T> = T extends undefined
 
 const INTERNAL_ERROR_SYMBOL = Symbol.for('INTERNAL_ERROR_KEY')
 
-export class InternalError<T extends ErrorDetails | undefined = ErrorDetails | undefined> extends Error {
+export class InternalError<
+  T extends ErrorDetails | undefined = ErrorDetails | undefined,
+> extends Error {
   public readonly errorCode: string
   public readonly details: T
 

--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -9,7 +9,7 @@ export type InternalErrorParams<T> = T extends undefined
 
 const INTERNAL_ERROR_SYMBOL = Symbol.for('INTERNAL_ERROR_KEY')
 
-export class InternalError<T extends ErrorDetails | undefined = undefined> extends Error {
+export class InternalError<T extends ErrorDetails | undefined = ErrorDetails | undefined> extends Error {
   public readonly errorCode: string
   public readonly details: T
 

--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -1,18 +1,23 @@
 import { isNativeError } from 'node:util/types'
 import type { ErrorDetails } from './types'
 
-export type InternalErrorParams<T = ErrorDetails> = {
+type BaseErrorParams = {
   message: string
   errorCode: string
-  details?: T
   cause?: unknown
 }
 
+export type InternalErrorParams<T> = T extends undefined
+  ? BaseErrorParams
+  : BaseErrorParams & {
+      details: T
+    }
+
 const INTERNAL_ERROR_SYMBOL = Symbol.for('INTERNAL_ERROR_KEY')
 
-export class InternalError<T = ErrorDetails> extends Error {
-  public readonly details?: T
+export class InternalError<T extends ErrorDetails | undefined = undefined> extends Error {
   public readonly errorCode: string
+  public readonly details: T
 
   constructor(params: InternalErrorParams<T>) {
     super(params.message, {
@@ -20,6 +25,7 @@ export class InternalError<T = ErrorDetails> extends Error {
     })
     // set the name as the class name for every class that extends InternalError
     this.name = this.constructor.name
+    // @ts-ignore
     this.details = params.details
     this.errorCode = params.errorCode
   }
@@ -32,7 +38,7 @@ Object.defineProperty(InternalError.prototype, INTERNAL_ERROR_SYMBOL, {
 export function isInternalError(error: unknown): error is InternalError {
   return (
     isNativeError(error) &&
-    // biome-ignore lint/suspicious/noExplicitAny: checking for existence of prop outside or Error interface
-    ((error as any)[INTERNAL_ERROR_SYMBOL] === true || error.name === 'InternalError')
+    ((INTERNAL_ERROR_SYMBOL in error && error[INTERNAL_ERROR_SYMBOL] === true) ||
+      error.name === 'InternalError')
   )
 }

--- a/src/errors/PublicNonRecoverableError.ts
+++ b/src/errors/PublicNonRecoverableError.ts
@@ -1,21 +1,25 @@
 import { isNativeError } from 'node:util/types'
-import type { ErrorDetails } from './types'
+import type { BaseErrorParams, ErrorDetails } from './types'
 
-export type PublicNonRecoverableErrorParams<T = ErrorDetails> = {
-  message: string
-  errorCode: string
-  details?: T
+type BasePublicErrorParams = BaseErrorParams & {
   httpStatusCode?: number
-  cause?: unknown
 }
+
+export type PublicNonRecoverableErrorParams<T> = T extends undefined
+  ? BasePublicErrorParams
+  : BasePublicErrorParams & {
+      details: T
+    }
 
 const PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL = Symbol.for('PUBLIC_NON_RECOVERABLE_ERROR_KEY')
 
 /**
  * This error is returned to the consumer of API
  */
-export class PublicNonRecoverableError<T = ErrorDetails> extends Error {
-  public readonly details?: T
+export class PublicNonRecoverableError<
+  T extends ErrorDetails | undefined = undefined,
+> extends Error {
+  public readonly details: T
   public readonly errorCode: string
   public readonly httpStatusCode: number
 
@@ -25,6 +29,7 @@ export class PublicNonRecoverableError<T = ErrorDetails> extends Error {
     })
     // set the name as the class name for every class that extends PublicNonRecoverableError
     this.name = this.constructor.name
+    // @ts-ignore
     this.details = params.details
     this.errorCode = params.errorCode
     this.httpStatusCode = params.httpStatusCode ?? 500
@@ -38,8 +43,8 @@ Object.defineProperty(PublicNonRecoverableError.prototype, PUBLIC_NON_RECOVERABL
 export function isPublicNonRecoverableError(error: unknown): error is PublicNonRecoverableError {
   return (
     isNativeError(error) &&
-    // biome-ignore lint/suspicious/noExplicitAny: checking for existence of prop outside or Error interface
-    ((error as any)[PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL] === true ||
+    ((PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL in error &&
+      error[PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL] === true) ||
       error.name === 'PublicNonRecoverableError')
   )
 }

--- a/src/errors/PublicNonRecoverableError.ts
+++ b/src/errors/PublicNonRecoverableError.ts
@@ -17,7 +17,7 @@ const PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL = Symbol.for('PUBLIC_NON_RECOVERABLE_E
  * This error is returned to the consumer of API
  */
 export class PublicNonRecoverableError<
-  T extends ErrorDetails | undefined = undefined,
+  T extends ErrorDetails | undefined = ErrorDetails | undefined,
 > extends Error {
   public readonly details: T
   public readonly errorCode: string

--- a/src/errors/publicErrors.ts
+++ b/src/errors/publicErrors.ts
@@ -3,7 +3,6 @@ import { constants as httpConstants } from 'node:http2'
 import type { FreeformRecord } from '../common/commonTypes'
 
 import { PublicNonRecoverableError } from './PublicNonRecoverableError'
-import type { ErrorDetails } from './types'
 
 export type CommonErrorParams = {
   message: string
@@ -33,7 +32,7 @@ export class RequestValidationError extends PublicNonRecoverableError<{
   }
 }
 
-export class AccessDeniedError extends PublicNonRecoverableError<undefined | ErrorDetails> {
+export class AccessDeniedError extends PublicNonRecoverableError {
   constructor(params: CommonErrorParams) {
     super({
       message: params.message,
@@ -45,7 +44,7 @@ export class AccessDeniedError extends PublicNonRecoverableError<undefined | Err
   }
 }
 
-export class EntityNotFoundError extends PublicNonRecoverableError<undefined | ErrorDetails> {
+export class EntityNotFoundError extends PublicNonRecoverableError {
   constructor(params: CommonErrorParams) {
     super({
       message: params.message,
@@ -57,7 +56,7 @@ export class EntityNotFoundError extends PublicNonRecoverableError<undefined | E
   }
 }
 
-export class EntityGoneError extends PublicNonRecoverableError<undefined | ErrorDetails> {
+export class EntityGoneError extends PublicNonRecoverableError {
   constructor(params: CommonErrorParams) {
     super({
       message: params.message,
@@ -68,7 +67,7 @@ export class EntityGoneError extends PublicNonRecoverableError<undefined | Error
   }
 }
 
-export class AuthFailedError extends PublicNonRecoverableError<undefined | ErrorDetails> {
+export class AuthFailedError extends PublicNonRecoverableError {
   constructor(params: OptionalMessageErrorParams = {}) {
     super({
       message: params.message ?? 'Authentication failed',

--- a/src/errors/publicErrors.ts
+++ b/src/errors/publicErrors.ts
@@ -3,6 +3,7 @@ import { constants as httpConstants } from 'node:http2'
 import type { FreeformRecord } from '../common/commonTypes'
 
 import { PublicNonRecoverableError } from './PublicNonRecoverableError'
+import type { ErrorDetails } from './types'
 
 export type CommonErrorParams = {
   message: string
@@ -17,7 +18,9 @@ export type ValidationError = {
   path: string[]
 }
 
-export class RequestValidationError extends PublicNonRecoverableError {
+export class RequestValidationError extends PublicNonRecoverableError<{
+  error: ValidationError[]
+}> {
   constructor(errors: ValidationError[]) {
     super({
       message: 'Invalid params',
@@ -30,7 +33,7 @@ export class RequestValidationError extends PublicNonRecoverableError {
   }
 }
 
-export class AccessDeniedError extends PublicNonRecoverableError {
+export class AccessDeniedError extends PublicNonRecoverableError<undefined | ErrorDetails> {
   constructor(params: CommonErrorParams) {
     super({
       message: params.message,
@@ -42,7 +45,7 @@ export class AccessDeniedError extends PublicNonRecoverableError {
   }
 }
 
-export class EntityNotFoundError extends PublicNonRecoverableError {
+export class EntityNotFoundError extends PublicNonRecoverableError<undefined | ErrorDetails> {
   constructor(params: CommonErrorParams) {
     super({
       message: params.message,
@@ -54,18 +57,18 @@ export class EntityNotFoundError extends PublicNonRecoverableError {
   }
 }
 
-export class EntityGoneError extends PublicNonRecoverableError {
+export class EntityGoneError extends PublicNonRecoverableError<undefined | ErrorDetails> {
   constructor(params: CommonErrorParams) {
     super({
       message: params.message,
       errorCode: 'ENTITY_GONE',
-      httpStatusCode: 410,
+      httpStatusCode: httpConstants.HTTP_STATUS_GONE,
       details: params.details,
     })
   }
 }
 
-export class AuthFailedError extends PublicNonRecoverableError {
+export class AuthFailedError extends PublicNonRecoverableError<undefined | ErrorDetails> {
   constructor(params: OptionalMessageErrorParams = {}) {
     super({
       message: params.message ?? 'Authentication failed',

--- a/src/errors/types.ts
+++ b/src/errors/types.ts
@@ -1,1 +1,7 @@
 export type ErrorDetails = Record<string, unknown>
+
+export type BaseErrorParams = {
+  message: string
+  errorCode: string
+  cause?: unknown
+}


### PR DESCRIPTION
This reverts commit e1c6b52fc2622f956b7febd9092db87320046bb4.

## Changes

This PR improves type-safety for InternalError details. The similar changes can be applied to PublicError once we agree on changes to Internal one.
Please take a look at the type-safety comparison below:
```
const a = new InternalError({ message: '', errorCode: '', details: { reason: '' } })
old: `details?: { reason: string } | undefined`
new: `details: { reason: string }`

const b = new InternalError({ message: '', errorCode: '' })
old: `details?: ErrorDetails | undefined`
new: `details: undefined`

const c = new InternalError<{ reason: string }>({ message: '', errorCode: '', details: { reason: '' } })
old: `details?: { reason: string } | undefined`
new: `details: { reason: string }`

const d = new InternalError<{ reason: string }>({ message: '', errorCode: '' })
old: no error, but it is typed as it should be defined
new: omitting details is not allowed - type-error

const d = new InternalError<number>({ message: '', errorCode: '' })
old: no error
new: passing number as generic value makes a type-error

const e = new InternalError({ message: '', errorCode: '', details: 1 })
old: no error
new: passing number as a details value makes a type-error
```

I've faced issues with the current implementation in accessing the details fields in custom errors. It led me to implement the fix.
```
class CustomError extends InternalError<{ reason: string }> { ... }

const err = new CustomError(..)

err.details.reason // type error as it is optional
```

Also, it has already caught incorrect details usage by passing an object that doesn't fulfill `ErrorDetails` type
https://github.com/lokalise/node-core/pull/180/files#diff-af89c8ebac1ff3b5f11f00ef931000c89c8a8e41b8181c2169a0e67ab9a1ad0fR320

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
