### PR TITLE
chore: add default error param generic value

### DIFF
--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -1,11 +1,12 @@
 import { isNativeError } from 'node:util/types'
 import type { BaseErrorParams, ErrorDetails } from './types'
 
-export type InternalErrorParams<T extends ErrorDetails | undefined = ErrorDetails | undefined> = T extends undefined
-  ? BaseErrorParams
-  : BaseErrorParams & {
-      details: T
-    }
+export type InternalErrorParams<T extends ErrorDetails | undefined = ErrorDetails | undefined> =
+  T extends undefined
+    ? BaseErrorParams
+    : BaseErrorParams & {
+        details: T
+      }
 
 const INTERNAL_ERROR_SYMBOL = Symbol.for('INTERNAL_ERROR_KEY')
 

--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -1,7 +1,7 @@
 import { isNativeError } from 'node:util/types'
 import type { BaseErrorParams, ErrorDetails } from './types'
 
-export type InternalErrorParams<T> = T extends undefined
+export type InternalErrorParams<T extends ErrorDetails | undefined = ErrorDetails | undefined> = T extends undefined
   ? BaseErrorParams
   : BaseErrorParams & {
       details: T

--- a/src/errors/PublicNonRecoverableError.ts
+++ b/src/errors/PublicNonRecoverableError.ts
@@ -5,7 +5,7 @@ type BasePublicErrorParams = BaseErrorParams & {
   httpStatusCode?: number
 }
 
-export type PublicNonRecoverableErrorParams<T> = T extends undefined
+export type PublicNonRecoverableErrorParams<T extends ErrorDetails | undefined = ErrorDetails | undefined> = T extends undefined
   ? BasePublicErrorParams
   : BasePublicErrorParams & {
       details: T

--- a/src/errors/PublicNonRecoverableError.ts
+++ b/src/errors/PublicNonRecoverableError.ts
@@ -5,7 +5,9 @@ type BasePublicErrorParams = BaseErrorParams & {
   httpStatusCode?: number
 }
 
-export type PublicNonRecoverableErrorParams<T extends ErrorDetails | undefined = ErrorDetails | undefined> = T extends undefined
+export type PublicNonRecoverableErrorParams<
+  T extends ErrorDetails | undefined = ErrorDetails | undefined,
+> = T extends undefined
   ? BasePublicErrorParams
   : BasePublicErrorParams & {
       details: T


### PR DESCRIPTION
## Changes

The PR  allows to use `PublicNonRecoverableErrorParams` without passing a generic type. Like
```
type MyType = PublicNonRecoverableErrorParams & { extraParam: string }
```
Without this improvement we would have to specify it explicitly like
```
type MyType = PublicNonRecoverableErrorParams<undefined | ErrorDetails> & { extraParam: string }
```

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
