### PR TITLE
feat: add safe error instanceof check

### DIFF
--- a/src/errors/InstanceofSafeError.spec.ts
+++ b/src/errors/InstanceofSafeError.spec.ts
@@ -1,0 +1,66 @@
+import vm from 'node:vm'
+import { InstanceofSafeError } from './InstanceofSafeError'
+
+class A extends InstanceofSafeError {}
+
+class B extends A {}
+
+class TestError extends Error {}
+
+describe('InstanceofSafeError', () => {
+  describe('instanceof behavior in the same realm', () => {
+    it('recognizes direct subclass', () => {
+      const a = new A('test')
+
+      expect(a.constructor.name).toBe('A')
+      expect(a instanceof InstanceofSafeError).toBe(true)
+      expect(a instanceof A).toBe(true)
+      expect(a instanceof B).toBe(false)
+    })
+
+    it('recognizes nested subclass', () => {
+      const b = new B('test')
+
+      expect(b.constructor.name).toBe('B')
+      expect(b instanceof InstanceofSafeError).toBe(true)
+      expect(b instanceof A).toBe(true)
+      expect(b instanceof B).toBe(true)
+    })
+  })
+
+  it('fails instanceof across vm contexts when using Error subclass', () => {
+    const context = vm.createContext({ Error })
+
+    vm.runInContext(
+      `
+      class TestError extends Error {}
+      globalThis.error = new TestError('from vm');
+    `,
+      context,
+    )
+
+    const { error } = context
+
+    expect(error instanceof Error).toBe(true)
+    expect(error instanceof TestError).toBe(false)
+  })
+
+  it('supports instanceof across vm contexts when using InstanceofSafeError subclass', () => {
+    const context = vm.createContext({ InstanceofSafeError })
+
+    vm.runInContext(
+      `
+      class A extends InstanceofSafeError {}
+      class B extends A {}
+      globalThis.error = new B('from vm');
+    `,
+      context,
+    )
+
+    const { error } = context
+
+    expect(error instanceof InstanceofSafeError).toBe(true)
+    expect(error instanceof A).toBe(true)
+    expect(error instanceof B).toBe(true)
+  })
+})

--- a/src/errors/InstanceofSafeError.ts
+++ b/src/errors/InstanceofSafeError.ts
@@ -1,0 +1,97 @@
+import { isNativeError } from 'node:util/types'
+
+const PROTOTYPE_PATH_DELIMITER = '.'
+
+const getPrototypeNamesPostError = (input: unknown): string[] => {
+  const names: string[] = []
+
+  const isFunction = typeof input === 'function'
+
+  // biome-ignore lint/complexity/noBannedTypes: describes prototype
+  let current: Function = isFunction ? input : Object.getPrototypeOf(input)
+
+  while (current !== null) {
+    const name = isFunction ? current.name : current.constructor.name
+
+    if (!name) {
+      break
+    }
+
+    names.push(name)
+    current = Object.getPrototypeOf(current)
+  }
+
+  const reversedNames = names.reverse()
+
+  const errorIndex = reversedNames.indexOf(Error.name)
+
+  if (errorIndex === -1) {
+    return reversedNames
+  }
+
+  return reversedNames.slice(errorIndex + 1)
+}
+
+const generatePrototypePaths = (arr: string[]): string[] => {
+  return arr.reduce<string[]>((acc, element) => {
+    const prev = acc.at(-1)
+
+    if (!prev) {
+      acc.push(element)
+    } else {
+      acc.push(`${prev}${PROTOTYPE_PATH_DELIMITER}${element}`)
+    }
+
+    return acc
+  }, [])
+}
+
+/**
+ * Custom error class that enables reliable instanceof checks across realms
+ * (e.g., iframes, workers, or Node.js VM).
+ * Also ensures that subclasses like `NotFoundError` have a consistent error name
+ * (i.e., `error.name` is set to the subclass name instead of `InstanceofSafeError`).
+ *
+ * How it works:
+ * - On instantiation, it collects the prototype chain names (e.g. ['InstanceofSafeError', 'Subclass1', 'Subclass2']),
+ *   generates inheritance paths like:
+ *   - 'InstanceofSafeError'
+ *   - 'InstanceofSafeError.Subclass1'
+ *   - 'InstanceofSafeError.Subclass1.Subclass2',
+ *   then assigns a corresponding `Symbol.for` as a property with value `true` on the instance for each path.
+ *
+ * - The custom `instanceof` logic (overriding `Symbol.hasInstance`) checks if the corresponding
+ *   symbol for the constructor’s prototype path exists on the tested object.
+ *
+ * This technique allows `instanceof` to succeed across realms where normal prototype chain checks fail,
+ * because symbols created via `Symbol.for` are shared globally and can be reliably compared.
+ */
+export class InstanceofSafeError extends Error {
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options)
+
+    // Set the error's name to the name of the class that was instantiated
+    this.name = new.target.name
+
+    const prototypeNames = getPrototypeNamesPostError(this)
+    const prototypePaths = generatePrototypePaths(prototypeNames)
+
+    for (const prototypePath of prototypePaths) {
+      const symbol = Symbol.for(prototypePath)
+
+      Object.defineProperty(this, symbol, { value: true })
+    }
+  }
+
+  static override [Symbol.hasInstance](val: unknown): boolean {
+    if (!isNativeError(val)) {
+      return false
+    }
+
+    // biome-ignore lint/complexity/noThisInStatic: intentional to support subclasses
+    const prototypeNames = getPrototypeNamesPostError(this)
+    const symbol = Symbol.for(prototypeNames.join(PROTOTYPE_PATH_DELIMITER))
+
+    return symbol in val && val[symbol] === true
+  }
+}

--- a/src/errors/InternalError.ts
+++ b/src/errors/InternalError.ts
@@ -1,4 +1,5 @@
 import { isNativeError } from 'node:util/types'
+import { InstanceofSafeError } from './InstanceofSafeError'
 import type { BaseErrorParams, ErrorDetails } from './types'
 
 export type InternalErrorParams<T extends ErrorDetails | undefined = ErrorDetails | undefined> =
@@ -12,7 +13,7 @@ const INTERNAL_ERROR_SYMBOL = Symbol.for('INTERNAL_ERROR_KEY')
 
 export class InternalError<
   T extends ErrorDetails | undefined = ErrorDetails | undefined,
-> extends Error {
+> extends InstanceofSafeError {
   public readonly errorCode: string
   public readonly details: T
 

--- a/src/errors/PublicNonRecoverableError.ts
+++ b/src/errors/PublicNonRecoverableError.ts
@@ -1,4 +1,5 @@
 import { isNativeError } from 'node:util/types'
+import { InstanceofSafeError } from './InstanceofSafeError'
 import type { BaseErrorParams, ErrorDetails } from './types'
 
 type BasePublicErrorParams = BaseErrorParams & {
@@ -20,7 +21,7 @@ const PUBLIC_NON_RECOVERABLE_ERROR_SYMBOL = Symbol.for('PUBLIC_NON_RECOVERABLE_E
  */
 export class PublicNonRecoverableError<
   T extends ErrorDetails | undefined = ErrorDetails | undefined,
-> extends Error {
+> extends InstanceofSafeError {
   public readonly details: T
   public readonly errorCode: string
   public readonly httpStatusCode: number


### PR DESCRIPTION
## Changes

Introduces InstanceofSafeError, a custom error class that enables reliable instanceof checks across JavaScript realms (e.g., iframes, workers, Node.js VM), where normal prototype checks fail.

It works by creating unique symbols for each inheritance path and assigning them to the instance. The overridden Symbol.hasInstance uses these symbols to identify subclasses across contexts correctly.

It also ensures error names reflect the actual subclass for clearer debugging.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary
