### PR TITLE
feat: let observability managers propagate transaction context

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,33 @@ An interface for tracking background transactions with the following methods:
 - `startWithGroup(transactionName, uniqueTransactionKey, transactionGroup)` - Creates and starts a background transaction related to a specified group
 - `stop(uniqueTransactionKey, wasSuccessful?)` - Ends the transaction
 - `addCustomAttributes(uniqueTransactionKey, atts)` - Adds custom attributes to the current transaction
+- `runInSpanContext(uniqueTransactionKey, fn)` (optional) - Runs `fn` with the transaction set as the active one
+
+`start` and `stop` are two separate calls and cannot express a scope, so implementations able to propagate context opt
+in by providing `runInSpanContext`. Consumers should not call it directly - use `runInTransactionContext` below, which
+handles managers that do not support it.
+
+### runInTransactionContext
+
+Runs a function within the observability context of an already started transaction, so that work performed inside it
+(spans, queries, outgoing calls) is recorded as part of that transaction instead of as detached top-level work. Falls
+back to plain execution when the manager is missing or cannot propagate context, so instrumented code never fails
+because of its observability tooling.
+
+```ts
+import { runInTransactionContext } from '@lokalise/node-core'
+
+observabilityManager.start('processOrder', 'order-123')
+try {
+  // spans created while processing become part of the `order-123` transaction
+  await runInTransactionContext(observabilityManager, 'order-123', () => processOrder(order))
+} finally {
+  observabilityManager.stop('order-123')
+}
+```
+
+Prefer it over an inline `manager.runInSpanContext?.(key, fn) ?? fn()`, which executes `fn` twice whenever it
+legitimately returns `undefined` or `null`.
 
 ### MultiTransactionObservabilityManager
 
@@ -238,6 +265,9 @@ const multiManager = new MultiTransactionObservabilityManager([
 
 multiManager.start('processOrder', 'order-123')
 ```
+
+`runInSpanContext` nests the contexts of every wrapped manager able to propagate one, so the function runs within all of
+them; managers without context propagation are skipped.
 
 ### NoopObservabilityManager
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ them; managers without context propagation are skipped.
 
 ### NoopObservabilityManager
 
-A no-operation implementation of `TransactionObservabilityManager`. All methods are implemented but do nothing. Use this when you need to satisfy a `TransactionObservabilityManager` dependency but don't want any actual observability tracking to occur.
+A no-operation implementation of `TransactionObservabilityManager`. All methods are implemented and do nothing, except `runInSpanContext`, which runs the given function and returns its result without propagating any context. Use this when you need to satisfy a `TransactionObservabilityManager` dependency but don't want any actual observability tracking to occur.
 
 ```ts
 import { NoopObservabilityManager } from '@lokalise/node-core'

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,7 @@ export { waitAndRetry } from './utils/waitUtils'
 export type { TransactionObservabilityManager } from './observability/observabilityTypes'
 export { MultiTransactionObservabilityManager } from './observability/MultiTransactionObservabilityManager'
 export { NoopObservabilityManager } from './observability/NoopObservabilityManager'
+export { runInTransactionContext } from './observability/runInTransactionContext'
 
 export {
   generateChecksumForReadable,

--- a/src/observability/MultiTransactionObservabilityManager.spec.ts
+++ b/src/observability/MultiTransactionObservabilityManager.spec.ts
@@ -61,6 +61,60 @@ describe('MultiTransactionObservabilityManager', () => {
       expect(spy2).toHaveBeenCalledWith('uniqueTransactionKey', wasSuccessful)
     },
   )
+
+  describe('runInSpanContext', () => {
+    it('nests the contexts of all managers supporting it', () => {
+      const activeContexts: string[] = []
+      const buildContextAwareManager = (name: string): TransactionObservabilityManager => ({
+        start: () => {},
+        startWithGroup: () => {},
+        stop: () => {},
+        addCustomAttributes: () => {},
+        runInSpanContext: <T>(_key: string, fn: () => T): T => {
+          activeContexts.push(name)
+          try {
+            return fn()
+          } finally {
+            activeContexts.splice(activeContexts.indexOf(name), 1)
+          }
+        },
+      })
+      const manager = new MultiTransactionObservabilityManager([
+        buildContextAwareManager('first'),
+        buildContextAwareManager('second'),
+      ])
+
+      const contextsDuringExecution = manager.runInSpanContext('uniqueTransactionKey', () => [
+        ...activeContexts,
+      ])
+
+      expect(contextsDuringExecution).toEqual(['first', 'second'])
+      expect(activeContexts).toEqual([])
+    })
+
+    it('skips managers without context propagation', () => {
+      const runInSpanContext = vi.fn((_key: string, fn: () => unknown) => fn())
+      const manager = new MultiTransactionObservabilityManager([
+        new FakeTransactionManager(),
+        {
+          start: () => {},
+          startWithGroup: () => {},
+          stop: () => {},
+          addCustomAttributes: () => {},
+          runInSpanContext: runInSpanContext as TransactionObservabilityManager['runInSpanContext'],
+        },
+      ])
+
+      expect(manager.runInSpanContext('uniqueTransactionKey', () => 'result')).toBe('result')
+      expect(runInSpanContext).toHaveBeenCalledWith('uniqueTransactionKey', expect.any(Function))
+    })
+
+    it('executes the function when no manager supports context propagation', () => {
+      const manager = new MultiTransactionObservabilityManager([new FakeTransactionManager()])
+
+      expect(manager.runInSpanContext('uniqueTransactionKey', () => 'result')).toBe('result')
+    })
+  })
 })
 
 class FakeTransactionManager implements TransactionObservabilityManager {

--- a/src/observability/MultiTransactionObservabilityManager.ts
+++ b/src/observability/MultiTransactionObservabilityManager.ts
@@ -1,4 +1,5 @@
 import type { TransactionObservabilityManager } from './observabilityTypes'
+import { runInTransactionContext } from './runInTransactionContext'
 
 /**
  * Groups different TransactionObservabilityManager instances into one
@@ -40,5 +41,16 @@ export class MultiTransactionObservabilityManager implements TransactionObservab
     for (const manager of this.managers) {
       manager.addCustomAttributes(uniqueTransactionKey, atts)
     }
+  }
+
+  /**
+   * Nests the contexts of every manager able to propagate one, so that the function runs within
+   * all of them. Managers without context propagation are skipped.
+   */
+  runInSpanContext<T>(uniqueTransactionKey: string, fn: () => T): T {
+    return this.managers.reduceRight<() => T>(
+      (next, manager) => () => runInTransactionContext(manager, uniqueTransactionKey, next),
+      fn,
+    )()
   }
 }

--- a/src/observability/NoopObservabilityManager.ts
+++ b/src/observability/NoopObservabilityManager.ts
@@ -58,4 +58,13 @@ export class NoopObservabilityManager implements TransactionObservabilityManager
   ): void {
     // noop
   }
+
+  /**
+   * No-op implementation of runInSpanContext. Runs the given function as-is.
+   * @param _uniqueTransactionKey - Ignored
+   * @param fn - Executed without any context propagation
+   */
+  runInSpanContext<T>(_uniqueTransactionKey: string, fn: () => T): T {
+    return fn()
+  }
 }

--- a/src/observability/NoopObservabilityManager.ts
+++ b/src/observability/NoopObservabilityManager.ts
@@ -2,7 +2,8 @@ import type { TransactionObservabilityManager } from './observabilityTypes'
 
 /**
  * A no-operation implementation of TransactionObservabilityManager.
- * All methods are implemented but do nothing.
+ * All methods are implemented and do nothing, except `runInSpanContext`, which runs the given
+ * function and returns its result without propagating any context.
  *
  * Use this implementation when you need to satisfy a TransactionObservabilityManager
  * dependency but don't want any actual observability tracking to occur.

--- a/src/observability/observabilityTypes.ts
+++ b/src/observability/observabilityTypes.ts
@@ -34,4 +34,21 @@ export type TransactionObservabilityManager = {
     uniqueTransactionKey: string,
     atts: { [key: string]: string | number | boolean },
   ): void
+
+  /**
+   * Runs the given function with the identified transaction set as the active one, so that work
+   * performed inside it (spans, queries, outgoing calls) is recorded as part of the transaction
+   * instead of as detached top-level work.
+   *
+   * Optional, because `start` and `stop` are two separate calls and cannot express a scope:
+   * implementations able to propagate context opt in by providing this method. Callers must treat
+   * its absence as "no context propagation available" and just invoke the function - use
+   * `runInTransactionContext` instead of calling this directly.
+   *
+   * The name refers to the span of the underlying tracer, which is what implementations activate.
+   *
+   * @param uniqueTransactionKey - used for identifying the ongoing transaction to make active
+   * @param fn - executed within the transaction context, its return value is passed through
+   */
+  runInSpanContext?: <T>(uniqueTransactionKey: string, fn: () => T) => T
 }

--- a/src/observability/runInTransactionContext.spec.ts
+++ b/src/observability/runInTransactionContext.spec.ts
@@ -1,0 +1,46 @@
+import type { TransactionObservabilityManager } from './observabilityTypes'
+import { runInTransactionContext } from './runInTransactionContext'
+
+describe('runInTransactionContext', () => {
+  const buildManager = (): TransactionObservabilityManager => ({
+    start: () => {},
+    startWithGroup: () => {},
+    stop: () => {},
+    addCustomAttributes: () => {},
+  })
+
+  it('executes the function when there is no manager', () => {
+    expect(runInTransactionContext(undefined, 'key', () => 'result')).toBe('result')
+  })
+
+  it('executes the function when the manager cannot propagate context', () => {
+    expect(runInTransactionContext(buildManager(), 'key', () => 'result')).toBe('result')
+  })
+
+  it('delegates to the manager when it can propagate context', () => {
+    const runInSpanContext = vi.fn((_key: string, fn: () => unknown) => fn())
+    const manager: TransactionObservabilityManager = {
+      ...buildManager(),
+      runInSpanContext: runInSpanContext as TransactionObservabilityManager['runInSpanContext'],
+    }
+
+    expect(runInTransactionContext(manager, 'key', () => 'result')).toBe('result')
+    expect(runInSpanContext).toHaveBeenCalledWith('key', expect.any(Function))
+  })
+
+  it('executes the function exactly once when it returns undefined', () => {
+    const fn = vi.fn(() => undefined)
+
+    expect(runInTransactionContext(buildManager(), 'key', fn)).toBeUndefined()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes through the value returned by the manager', () => {
+    const manager: TransactionObservabilityManager = {
+      ...buildManager(),
+      runInSpanContext: <T>() => 'from-manager' as T,
+    }
+
+    expect(runInTransactionContext(manager, 'key', () => 'result')).toBe('from-manager')
+  })
+})

--- a/src/observability/runInTransactionContext.spec.ts
+++ b/src/observability/runInTransactionContext.spec.ts
@@ -9,6 +9,11 @@ describe('runInTransactionContext', () => {
     addCustomAttributes: () => {},
   })
 
+  const buildPropagatingManager = (): TransactionObservabilityManager => ({
+    ...buildManager(),
+    runInSpanContext: <T>(_uniqueTransactionKey: string, fn: () => T): T => fn(),
+  })
+
   it('executes the function when there is no manager', () => {
     expect(runInTransactionContext(undefined, 'key', () => 'result')).toBe('result')
   })
@@ -28,12 +33,25 @@ describe('runInTransactionContext', () => {
     expect(runInSpanContext).toHaveBeenCalledWith('key', expect.any(Function))
   })
 
-  it('executes the function exactly once when it returns undefined', () => {
-    const fn = vi.fn(() => undefined)
+  it.each([undefined, null])(
+    'executes the function exactly once when it returns %s and context cannot be propagated',
+    (returnValue) => {
+      const fn = vi.fn(() => returnValue)
 
-    expect(runInTransactionContext(buildManager(), 'key', fn)).toBeUndefined()
-    expect(fn).toHaveBeenCalledTimes(1)
-  })
+      expect(runInTransactionContext(buildManager(), 'key', fn)).toBe(returnValue)
+      expect(fn).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it.each([undefined, null])(
+    'executes the function exactly once when it returns %s and context is propagated',
+    (returnValue) => {
+      const fn = vi.fn(() => returnValue)
+
+      expect(runInTransactionContext(buildPropagatingManager(), 'key', fn)).toBe(returnValue)
+      expect(fn).toHaveBeenCalledTimes(1)
+    },
+  )
 
   it('passes through the value returned by the manager', () => {
     const manager: TransactionObservabilityManager = {

--- a/src/observability/runInTransactionContext.ts
+++ b/src/observability/runInTransactionContext.ts
@@ -1,0 +1,23 @@
+import type { TransactionObservabilityManager } from './observabilityTypes'
+
+/**
+ * Runs the given function within the observability context of an already started transaction, so
+ * that work performed inside it (spans, queries, outgoing calls) is recorded as part of that
+ * transaction instead of as detached top-level work.
+ *
+ * Falls back to plain execution when no manager is given, or when the manager cannot propagate
+ * context, so instrumented code never fails because of its observability tooling.
+ *
+ * Prefer this over calling the optional `runInSpanContext` directly: an inline
+ * `manager.runInSpanContext?.(key, fn) ?? fn()` executes `fn` twice whenever it legitimately
+ * returns `undefined` or `null`.
+ *
+ * @param manager - the manager the transaction was started on
+ * @param uniqueTransactionKey - the key the transaction was started with
+ * @param fn - executed within the transaction context, its return value is passed through
+ */
+export const runInTransactionContext = <T>(
+  manager: TransactionObservabilityManager | undefined,
+  uniqueTransactionKey: string,
+  fn: () => T,
+): T => (manager?.runInSpanContext ? manager.runInSpanContext(uniqueTransactionKey, fn) : fn())


### PR DESCRIPTION
## Changes

Third part of a chain that fixes background jobs producing no usable traces (lokalise/fastify-extras#456, lokalise/shared-ts-libs#1203). Those two work today via structural typing; this makes the capability part of the contract.

`start` and `stop` are two separate calls and cannot express a scope, so a `TransactionObservabilityManager` has no way to make the transaction it started the *active* one. Consumers instrumenting background work — background jobs, queue consumers — could only create a transaction, never run anything inside it. Consequences: spans produced while the work ran became detached roots instead of children of the transaction, and anything reading the active span (custom attributes, user id, controller name) saw nothing.

This adds an optional member to the interface:

```ts
runInSpanContext?: <T>(uniqueTransactionKey: string, fn: () => T) => T
```

Optional so it stays backwards compatible: implementations able to propagate context opt in. The OpenTelemetry manager in `@lokalise/fastify-extras` already exposes exactly this method and satisfies it as-is, which is also why the name keeps its `Span` wording rather than matching the interface's "transaction" vocabulary — renaming would break the one implementation that already provides it, for no functional gain.

Both managers shipped here implement it:

- `NoopObservabilityManager` runs the function as-is.
- `MultiTransactionObservabilityManager` nests the contexts of every wrapped manager that supports one, skipping those that don't, so the function runs inside all of them.

Also exports a `runInTransactionContext(manager, key, fn)` helper. Because the member is optional, every consumer needs a fallback for managers without it, and the obvious inline form is a trap:

```ts
manager.runInSpanContext?.(key, fn) ?? fn() // runs fn twice when fn returns undefined or null
```

The helper handles that (there's a test pinning it), accepts `undefined` managers, and is what the docs point consumers at.

#### Verification

`biome check` and `tsc` clean; 540 tests pass.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

AI assisted with this PR (Claude Code).
