### PR TITLE
fix: tighten the transaction context propagation contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,22 +229,31 @@ An interface for tracking background transactions with the following methods:
 in by providing `runInSpanContext`. Consumers should not call it directly - use `runInTransactionContext` below, which
 handles managers that do not support it.
 
+Implementations of `runInSpanContext` must call `fn` exactly once, return its value and let the errors it throws
+through unchanged, because callers put their business logic in `fn` and cannot retry it. When `fn` returns a promise,
+they must also keep the context active for the lifetime of that promise, which needs `AsyncLocalStorage` or an
+equivalent: activating the span and restoring the previous one in a synchronous `finally` restores it at the first
+`await`, leaving everything after it detached again.
+
 ### runInTransactionContext
 
 Runs a function within the observability context of an already started transaction, so that work performed inside it
-(spans, queries, outgoing calls) is recorded as part of that transaction instead of as detached top-level work. Falls
-back to plain execution when the manager is missing or cannot propagate context, so instrumented code never fails
-because of its observability tooling.
+(spans, queries, outgoing calls) is recorded as part of that transaction instead of as detached top-level work. Runs the
+function directly when the manager is missing or cannot propagate context, so a manager without context propagation
+costs the caller nothing. When the manager can propagate context, it is the one that invokes the function, and its
+errors reach the caller: a manager breaking the contract above can skip the work or fail the caller.
 
 ```ts
 import { runInTransactionContext } from '@lokalise/node-core'
 
 observabilityManager.start('processOrder', 'order-123')
+let wasSuccessful = false
 try {
   // spans created while processing become part of the `order-123` transaction
   await runInTransactionContext(observabilityManager, 'order-123', () => processOrder(order))
+  wasSuccessful = true
 } finally {
-  observabilityManager.stop('order-123')
+  observabilityManager.stop('order-123', wasSuccessful)
 }
 ```
 
@@ -267,7 +276,8 @@ multiManager.start('processOrder', 'order-123')
 ```
 
 `runInSpanContext` nests the contexts of every wrapped manager able to propagate one, so the function runs within all of
-them; managers without context propagation are skipped.
+them; managers without context propagation are skipped. It is only present when at least one wrapped manager can
+propagate context, so checking for it answers whether the wrapped managers will connect the traces.
 
 ### NoopObservabilityManager
 

--- a/src/observability/MultiTransactionObservabilityManager.spec.ts
+++ b/src/observability/MultiTransactionObservabilityManager.spec.ts
@@ -1,5 +1,6 @@
 import { MultiTransactionObservabilityManager } from './MultiTransactionObservabilityManager'
 import type { TransactionObservabilityManager } from './observabilityTypes'
+import { runInTransactionContext } from './runInTransactionContext'
 
 describe('MultiTransactionObservabilityManager', () => {
   let multiTransactionObservabilityManager: MultiTransactionObservabilityManager
@@ -84,9 +85,11 @@ describe('MultiTransactionObservabilityManager', () => {
         buildContextAwareManager('second'),
       ])
 
-      const contextsDuringExecution = manager.runInSpanContext('uniqueTransactionKey', () => [
-        ...activeContexts,
-      ])
+      const contextsDuringExecution = runInTransactionContext(
+        manager,
+        'uniqueTransactionKey',
+        () => [...activeContexts],
+      )
 
       expect(contextsDuringExecution).toEqual(['first', 'second'])
       expect(activeContexts).toEqual([])
@@ -105,14 +108,34 @@ describe('MultiTransactionObservabilityManager', () => {
         },
       ])
 
-      expect(manager.runInSpanContext('uniqueTransactionKey', () => 'result')).toBe('result')
+      expect(runInTransactionContext(manager, 'uniqueTransactionKey', () => 'result')).toBe(
+        'result',
+      )
       expect(runInSpanContext).toHaveBeenCalledWith('uniqueTransactionKey', expect.any(Function))
     })
 
-    it('executes the function when no manager supports context propagation', () => {
+    it('is not exposed when no manager supports context propagation', () => {
       const manager = new MultiTransactionObservabilityManager([new FakeTransactionManager()])
 
-      expect(manager.runInSpanContext('uniqueTransactionKey', () => 'result')).toBe('result')
+      expect(manager.runInSpanContext).toBeUndefined()
+      expect(runInTransactionContext(manager, 'uniqueTransactionKey', () => 'result')).toBe(
+        'result',
+      )
+    })
+
+    it('is exposed when at least one manager supports context propagation', () => {
+      const manager = new MultiTransactionObservabilityManager([
+        new FakeTransactionManager(),
+        {
+          start: () => {},
+          startWithGroup: () => {},
+          stop: () => {},
+          addCustomAttributes: () => {},
+          runInSpanContext: <T>(_key: string, fn: () => T): T => fn(),
+        },
+      ])
+
+      expect(manager.runInSpanContext).toBeDefined()
     })
   })
 })

--- a/src/observability/MultiTransactionObservabilityManager.ts
+++ b/src/observability/MultiTransactionObservabilityManager.ts
@@ -8,8 +8,27 @@ import { runInTransactionContext } from './runInTransactionContext'
 export class MultiTransactionObservabilityManager implements TransactionObservabilityManager {
   private readonly managers: TransactionObservabilityManager[]
 
+  /**
+   * Nests the contexts of every manager able to propagate one, so that the function runs within
+   * all of them. Managers without context propagation are skipped.
+   *
+   * Only assigned when at least one wrapped manager can propagate context, so that its presence
+   * keeps meaning what the interface says it means: a consumer checking for it to find out whether
+   * its traces will be connected gets an answer about the wrapped managers instead of about this
+   * wrapper. Call it through `runInTransactionContext`, which handles its absence.
+   */
+  readonly runInSpanContext?: <T>(uniqueTransactionKey: string, fn: () => T) => T
+
   constructor(managers: TransactionObservabilityManager[]) {
     this.managers = managers
+
+    if (managers.some((manager) => manager.runInSpanContext)) {
+      this.runInSpanContext = <T>(uniqueTransactionKey: string, fn: () => T): T =>
+        managers.reduceRight<() => T>(
+          (next, manager) => () => runInTransactionContext(manager, uniqueTransactionKey, next),
+          fn,
+        )()
+    }
   }
 
   start(transactionName: string, uniqueTransactionKey: string): void {
@@ -41,16 +60,5 @@ export class MultiTransactionObservabilityManager implements TransactionObservab
     for (const manager of this.managers) {
       manager.addCustomAttributes(uniqueTransactionKey, atts)
     }
-  }
-
-  /**
-   * Nests the contexts of every manager able to propagate one, so that the function runs within
-   * all of them. Managers without context propagation are skipped.
-   */
-  runInSpanContext<T>(uniqueTransactionKey: string, fn: () => T): T {
-    return this.managers.reduceRight<() => T>(
-      (next, manager) => () => runInTransactionContext(manager, uniqueTransactionKey, next),
-      fn,
-    )()
   }
 }

--- a/src/observability/observabilityTypes.ts
+++ b/src/observability/observabilityTypes.ts
@@ -47,6 +47,17 @@ export type TransactionObservabilityManager = {
    *
    * The name refers to the span of the underlying tracer, which is what implementations activate.
    *
+   * Implementations must:
+   *
+   * - call `fn` exactly once, return its value, and let the errors it throws through unchanged.
+   *   Callers put their business logic in `fn` and cannot retry it: a caller that retried after an
+   *   error would run `fn` a second time whenever the error came from `fn` itself. Not calling `fn`
+   *   because the key is unknown silently drops the caller's work.
+   * - keep the context active for the lifetime of the promise when `fn` returns one, which needs
+   *   `AsyncLocalStorage` or an equivalent. Activating the span and restoring the previous one in a
+   *   synchronous `finally` satisfies this type, but the restore then happens at the first `await`,
+   *   and everything after it is recorded detached again.
+   *
    * @param uniqueTransactionKey - used for identifying the ongoing transaction to make active
    * @param fn - executed within the transaction context, its return value is passed through
    */

--- a/src/observability/runInTransactionContext.ts
+++ b/src/observability/runInTransactionContext.ts
@@ -5,8 +5,14 @@ import type { TransactionObservabilityManager } from './observabilityTypes'
  * that work performed inside it (spans, queries, outgoing calls) is recorded as part of that
  * transaction instead of as detached top-level work.
  *
- * Falls back to plain execution when no manager is given, or when the manager cannot propagate
- * context, so instrumented code never fails because of its observability tooling.
+ * Runs the function directly when no manager is given, or when the manager cannot propagate
+ * context, so that a manager without context propagation costs the caller nothing.
+ *
+ * When the manager can propagate context, it is the one that invokes the function, and this helper
+ * neither catches its errors nor runs the function itself afterwards: a manager that throws after
+ * the function already ran would otherwise run it twice. Implementations are required to call the
+ * function exactly once and let its errors through (see `runInSpanContext`), so a manager that
+ * breaks that contract can skip the work or fail the caller.
  *
  * Prefer this over calling the optional `runInSpanContext` directly: an inline
  * `manager.runInSpanContext?.(key, fn) ?? fn()` executes `fn` twice whenever it legitimately


### PR DESCRIPTION
## Changes

Follow-up to #316 (shipped in 14.9.0). Four gaps found reviewing that PR, none of them changing what a working implementation does.

`runInTransactionContext` documented itself as falling back "so instrumented code never fails because of its observability tooling", while it only guards against a missing `runInSpanContext`. Once a manager provides one, that manager decides whether `fn` runs at all: a tracer that throws fails the caller, and one that looks the key up and returns early on an unknown key drops the work and hands the caller `undefined` as a normal result. Catching and rerunning `fn` is not an option, because a manager that throws after `fn` already ran would run it twice. So the claim is gone, the docs describe what actually happens, and the interface now states the implementation contract: call `fn` exactly once, return its value, let its errors through.

The interface also said nothing about async, while the documented example passes an async function. Activating the span and restoring the previous one in a synchronous `finally` satisfies `fn: () => T` (it is the shape of the test double in the existing spec) but restores the context at the first `await`, leaving every span after it detached, which is the problem #316 exists to fix. Implementations now have to keep the context active for the lifetime of a returned promise, which means `AsyncLocalStorage` or an equivalent.

`MultiTransactionObservabilityManager` defined `runInSpanContext` unconditionally, so a wrapper around only non-propagating managers still advertised the capability. The interface tells callers to read its absence as "no context propagation available", so a consumer checking presence (to warn at startup that traces will be detached, say) got an answer about the wrapper rather than about the managers inside it. It is now assigned in the constructor only when at least one wrapped manager has it. Execution of `fn` is unchanged either way; the specs call it through `runInTransactionContext`, which is what consumers should do anyway, and two tests pin the capability signal.

The README example ended its transaction with a bare `stop('order-123')` in a `finally`, so a `processOrder` that throws ends the transaction without being marked unsuccessful, leaving failed background jobs indistinguishable from successful ones in the consumer's APM. It now tracks the outcome and passes it.

#### Verification

`biome check` and `tsc` clean; 546 tests pass.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [x] I've updated the documentation, or no changes were necessary
- [x] I've updated the tests, or no changes were necessary

AI assisted with this PR (Claude Code).
